### PR TITLE
V1.2: Refactor Parser for "Edit", "Delete", "Find", "Help" and their commands

### DIFF
--- a/src/main/java/seedu/recipe/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/EditCommand.java
@@ -89,6 +89,7 @@ public class EditCommand extends Command {
         Recipe recipeToEdit = lastShownList.get(index.getZeroBased());
         Recipe editedRecipe = createEditedRecipe(recipeToEdit, editRecipeDescriptor);
 
+        // TODO: ensure that these model methods work properly
         if (!recipeToEdit.isSameRecipe(editedRecipe) && model.hasRecipe(editedRecipe)) {
             throw new CommandException(MESSAGE_DUPLICATE_RECIPE);
         }
@@ -106,11 +107,24 @@ public class EditCommand extends Command {
         assert recipeToEdit != null;
 
         Name updatedName = editRecipeDescriptor.getName().orElse(recipeToEdit.getName());
-        List<Ingredient> updatedIngredients = editRecipeDescriptor.getPhone().orElse(recipeToEdit.getIngredient());
-        Email updatedEmail = editRecipeDescriptor.getEmail().orElse(recipeToEdit.getEmail());
-        Address updatedAddress = editRecipeDescriptor.getAddress().orElse(recipeToEdit.getAddress());
-        Set<Tag> updatedTags = editRecipeDescriptor.getTags().orElse(recipeToEdit.getTags());
-        return new Recipe(updatedName, updatedIngredient, updatedEmail, updatedAddress, updatedTags, null);
+        Recipe newRecipe = new Recipe(updatedName);
+
+        RecipeDuration updatedDuration = editRecipeDescriptor.getDuration().orElse(recipeToEdit.getDurationNullable());
+        newRecipe.setDuration(updatedDuration);
+
+        RecipePortion updatedPortion = editRecipeDescriptor.getPortion().orElse(recipeToEdit.getPortionNullable());
+        newRecipe.setPortion(updatedPortion);
+
+        Tag[] updatedTags = editRecipeDescriptor.getTags().orElse(recipeToEdit.getTags()).toArray(Tag[]::new);
+        newRecipe.setTags(updatedTags);
+
+        Ingredient[] updatedIngredients = editRecipeDescriptor.getIngredients().orElse(recipeToEdit.getIngredients()).toArray(Ingredient[]::new);
+        newRecipe.setIngredients(updatedIngredients);
+
+        Step[] updatedSteps = editRecipeDescriptor.getSteps().orElse(recipeToEdit.getSteps()).toArray(Step[]::new);
+        newRecipe.setSteps(updatedSteps);
+
+        return newRecipe;
     }
 
     @Override

--- a/src/main/java/seedu/recipe/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/EditCommand.java
@@ -1,10 +1,11 @@
 package seedu.recipe.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.recipe.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_DURATION;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_PORTION;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_INGREDIENT;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_STEP;
 import static seedu.recipe.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.recipe.model.Model.PREDICATE_SHOW_ALL_RECIPE;
 
@@ -38,13 +39,20 @@ public class EditCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_DURATION + "DURATION] "
+            + "[" + PREFIX_PORTION + "PORTION] "
             + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_INGREDIENT + "INGREDIENT]...\n"
+            + "[" + PREFIX_STEP + "STEP]...\n"
+
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + PREFIX_NAME + "Cacio e Pepe Pasta "
+            + PREFIX_PORTION + "1 - 2 portions "
+            + PREFIX_DURATION + "15 minutes "
+            + PREFIX_TAG + "Italian "
+            + PREFIX_INGREDIENT + "3 eggs "
+            + PREFIX_INGREDIENT + "parmesan cheese "
+            + PREFIX_INGREDIENT + "125g spaghetti noodles ";
 
     public static final String MESSAGE_EDIT_RECIPE_SUCCESS = "Edited Recipe: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/recipe/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/EditCommand.java
@@ -9,6 +9,7 @@ import static seedu.recipe.logic.parser.CliSyntax.PREFIX_STEP;
 import static seedu.recipe.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.recipe.model.Model.PREDICATE_SHOW_ALL_RECIPE;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +26,9 @@ import seedu.recipe.model.recipe.Email;
 import seedu.recipe.model.recipe.Ingredient;
 import seedu.recipe.model.recipe.Name;
 import seedu.recipe.model.recipe.Recipe;
+import seedu.recipe.model.recipe.RecipeDuration;
+import seedu.recipe.model.recipe.RecipePortion;
+import seedu.recipe.model.recipe.Step;
 import seedu.recipe.model.tag.Tag;
 
 /**
@@ -62,7 +66,7 @@ public class EditCommand extends Command {
     private final EditRecipeDescriptor editRecipeDescriptor;
 
     /**
-     * @param index of the recipe in the filtered recipe list to edit
+     * @param index                of the recipe in the filtered recipe list to edit
      * @param editRecipeDescriptor details to edit the recipe with
      */
     public EditCommand(Index index, EditRecipeDescriptor editRecipeDescriptor) {
@@ -133,12 +137,14 @@ public class EditCommand extends Command {
      */
     public static class EditRecipeDescriptor {
         private Name name;
-        private List<Ingredient> ingredients;
-        private Email email;
-        private Address address;
+        private RecipeDuration duration;
+        private RecipePortion portion;
         private Set<Tag> tags;
+        private List<Ingredient> ingredients;
+        private List<Step> steps;
 
-        public EditRecipeDescriptor() {}
+        public EditRecipeDescriptor() {
+        }
 
         /**
          * Copy constructor.
@@ -146,17 +152,18 @@ public class EditCommand extends Command {
          */
         public EditRecipeDescriptor(EditRecipeDescriptor toCopy) {
             setName(toCopy.name);
-            setPhone(toCopy.ingredients);
-            setEmail(toCopy.email);
-            setAddress(toCopy.address);
+            setDuration(toCopy.duration);
+            setPortion(toCopy.portion);
             setTags(toCopy.tags);
+            setIngredients(toCopy.ingredients);
+            setSteps(toCopy.steps);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, ingredients, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, duration, portion, tags, ingredients, steps);
         }
 
         public void setName(Name name) {
@@ -167,28 +174,20 @@ public class EditCommand extends Command {
             return Optional.ofNullable(name);
         }
 
-        public void setPhone(Ingredient ingredient) {
-            this.ingredient = ingredient;
+        public void setDuration(RecipeDuration duration) {
+            this.duration = duration;
         }
 
-        public Optional<Ingredient> getPhone() {
-            return Optional.ofNullable(ingredient);
+        public Optional<RecipeDuration> getDuration() {
+            return Optional.ofNullable(duration);
         }
 
-        public void setEmail(Email email) {
-            this.email = email;
+        public void setPortion(RecipePortion portion) {
+            this.portion = portion;
         }
 
-        public Optional<Email> getEmail() {
-            return Optional.ofNullable(email);
-        }
-
-        public void setAddress(Address address) {
-            this.address = address;
-        }
-
-        public Optional<Address> getAddress() {
-            return Optional.ofNullable(address);
+        public Optional<RecipePortion> getPortion() {
+            return Optional.ofNullable(portion);
         }
 
         /**
@@ -208,6 +207,22 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        public void setIngredients(List<Ingredient> ingredients) {
+            this.ingredients = (ingredients != null) ? new ArrayList<>(ingredients) : null;
+        }
+
+        public Optional<List<Ingredient>> getIngredients() {
+            return (ingredients != null) ? Optional.of(Collections.unmodifiableList(ingredients)) : Optional.empty();
+        }
+
+        public void setSteps(List<Step> steps) {
+            this.steps = (steps != null) ? new ArrayList<>(steps) : null;
+        }
+
+        public Optional<List<Step>> getSteps() {
+            return (steps != null) ? Optional.of(Collections.unmodifiableList(steps)) : Optional.empty();
+        }
+
         @Override
         public boolean equals(Object other) {
             // short circuit if same object
@@ -224,10 +239,11 @@ public class EditCommand extends Command {
             EditRecipeDescriptor e = (EditRecipeDescriptor) other;
 
             return getName().equals(e.getName())
-                    && getPhone().equals(e.getPhone())
-                    && getEmail().equals(e.getEmail())
-                    && getAddress().equals(e.getAddress())
-                    && getTags().equals(e.getTags());
+                    && getDuration().equals(e.getDuration())
+                    && getPortion().equals(e.getPortion())
+                    && getTags().equals(e.getTags())
+                    && getIngredients().equals(e.getIngredients())
+                    && getSteps().equals(e.getSteps());
         }
     }
 }

--- a/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
@@ -4,10 +4,13 @@ import seedu.recipe.commons.core.index.Index;
 import seedu.recipe.logic.commands.EditCommand;
 import seedu.recipe.logic.commands.EditCommand.EditRecipeDescriptor;
 import seedu.recipe.logic.parser.exceptions.ParseException;
+import seedu.recipe.model.recipe.Ingredient;
+import seedu.recipe.model.recipe.Step;
 import seedu.recipe.model.tag.Tag;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,16 +50,15 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editRecipeDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editRecipeDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        if (argMultimap.getValue(PREFIX_DURATION).isPresent()) {
+            editRecipeDescriptor.setDuration(ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get()));
         }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editRecipeDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
-        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editRecipeDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        if (argMultimap.getValue(PREFIX_PORTION).isPresent()) {
+            editRecipeDescriptor.setPortion(ParserUtil.parsePortion(argMultimap.getValue(PREFIX_PORTION).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editRecipeDescriptor::setTags);
+        parseIngredientsForEdit(argMultimap.getAllValues(PREFIX_INGREDIENT)).ifPresent(editRecipeDescriptor::setIngredients);
+        parseStepsForEdit(argMultimap.getAllValues(PREFIX_STEP)).ifPresent(editRecipeDescriptor::setSteps);
 
         if (!editRecipeDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -80,4 +82,23 @@ public class EditCommandParser implements Parser<EditCommand> {
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
+    private Optional<List<Ingredient>> parseIngredientsForEdit(Collection<String> ingredients) throws ParseException {
+        assert ingredients != null;
+
+        if (ingredients.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> ingredientList = ingredients.size() == 1 && ingredients.contains("") ? Collections.emptyList() : ingredients;
+        return Optional.of(ParserUtil.parseIngredients(ingredientList));
+    }
+
+    private Optional<List<Step>> parseStepsForEdit(Collection<String> steps) throws ParseException {
+        assert steps != null;
+
+        if (steps.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> stepsList = steps.size() == 1 && steps.contains("") ? Collections.emptyList() : steps;
+        return Optional.of(ParserUtil.parseSteps(stepsList));
+    }
 }

--- a/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
@@ -1,23 +1,24 @@
 package seedu.recipe.logic.parser;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.recipe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.recipe.logic.parser.CliSyntax.PREFIX_TAG;
+import seedu.recipe.commons.core.index.Index;
+import seedu.recipe.logic.commands.EditCommand;
+import seedu.recipe.logic.commands.EditCommand.EditRecipeDescriptor;
+import seedu.recipe.logic.parser.exceptions.ParseException;
+import seedu.recipe.model.tag.Tag;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import seedu.recipe.commons.core.index.Index;
-import seedu.recipe.logic.commands.EditCommand;
-import seedu.recipe.logic.commands.EditCommand.EditRecipeDescriptor;
-import seedu.recipe.logic.parser.exceptions.ParseException;
-import seedu.recipe.model.tag.Tag;
+import static java.util.Objects.requireNonNull;
+import static seedu.recipe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_DURATION;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_INGREDIENT;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_PORTION;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_STEP;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -32,7 +33,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DURATION, PREFIX_PORTION, PREFIX_TAG, PREFIX_INGREDIENT, PREFIX_STEP);
 
         Index index;
 

--- a/src/main/java/seedu/recipe/model/recipe/Recipe.java
+++ b/src/main/java/seedu/recipe/model/recipe/Recipe.java
@@ -51,6 +51,16 @@ public class Recipe {
         return duration.get();
     }
 
+    // nullable variants of getPortion and getDuration
+    // when we are okay with receiving null
+    public RecipePortion getPortionNullable() {
+        return portion.orElse(null);
+    }
+
+    public RecipeDuration getDurationNullable() {
+        return duration.orElse(null);
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
@@ -64,11 +74,11 @@ public class Recipe {
     }
 
     public void setPortion(RecipePortion portion) {
-        this.portion = Optional.of(portion);
+        this.portion = Optional.ofNullable(portion);
     }
 
     public void setDuration(RecipeDuration duration) {
-        this.duration = Optional.of(duration);
+        this.duration = Optional.ofNullable(duration);
     }
 
     public void setTags(Tag... tags) {
@@ -82,6 +92,7 @@ public class Recipe {
     public void setSteps(Step... steps) {
         this.steps.addAll(List.of(steps));
     }
+
 
 
     /**

--- a/src/main/java/seedu/recipe/ui/HelpWindow.java
+++ b/src/main/java/seedu/recipe/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.recipe.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2223s2-cs2103t-t13-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);


### PR DESCRIPTION
Closes #70 

- Major changes needed for "Edit" command
- Only changes needed for "Delete" command is the user guide URL in `HelpWindow`
- No change needed for "Find" command
- No change needed for "Help" command

Code does not pass build tests, but that is because this code relies on the changes made to`ParseUtil::parsePortion()`, `ParseUtil::parseDuration()`, and misc model changes introduced in #73 