### PR TITLE
V1.3b UI: Form Refactor

### DIFF
--- a/src/main/java/seedu/recipe/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/AddCommand.java
@@ -14,34 +14,34 @@ import seedu.recipe.model.Model;
 import seedu.recipe.model.recipe.Recipe;
 
 /**
- * Adds a recipe to the recipe book.
+ * Adds a recipe to the recipe book via a text command.
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a recipe to the recipe book. "
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + "[" + PREFIX_DURATION + "DURATION] "
-            + "[" + PREFIX_PORTION + "PORTION] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "[" + PREFIX_INGREDIENT + "INGREDIENT]...\n"
-            + "[" + PREFIX_STEP + "STEP]...\n"
+        + "Parameters: "
+        + PREFIX_NAME + "NAME "
+        + "[" + PREFIX_DURATION + "DURATION] "
+        + "[" + PREFIX_PORTION + "PORTION] "
+        + "[" + PREFIX_TAG + "TAG]...\n"
+        + "[" + PREFIX_INGREDIENT + "INGREDIENT]...\n"
+        + "[" + PREFIX_STEP + "STEP]...\n"
 
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Cacio e Pepe Pasta "
-            + PREFIX_PORTION + "1 - 2 portions "
-            + PREFIX_DURATION + "15 minutes "
-            + PREFIX_TAG + "Italian "
-            + PREFIX_INGREDIENT + "2 eggs "
-            + PREFIX_INGREDIENT + "parmesan cheese "
-            + PREFIX_INGREDIENT + "125g spaghetti noodles "
-            + PREFIX_STEP + "Heat a pot with water until it boils "
-            + PREFIX_STEP
-            + "Place the spaghetti in the pot and leave for 5 minutes or until al "
-            + "dente"
-            + PREFIX_STEP + "In a bowl, combine the parmesan and the egg yolks";
+        + "Example: " + COMMAND_WORD + " "
+        + PREFIX_NAME + "Cacio e Pepe Pasta "
+        + PREFIX_PORTION + "1 - 2 portions "
+        + PREFIX_DURATION + "15 minutes "
+        + PREFIX_TAG + "Italian "
+        + PREFIX_INGREDIENT + "2 eggs "
+        + PREFIX_INGREDIENT + "parmesan cheese "
+        + PREFIX_INGREDIENT + "125g spaghetti noodles "
+        + PREFIX_STEP + "Heat a pot with water until it boils "
+        + PREFIX_STEP
+        + "Place the spaghetti in the pot and leave for 5 minutes or until al "
+        + "dente"
+        + PREFIX_STEP + "In a bowl, combine the parmesan and the egg yolks";
 
     public static final String MESSAGE_SUCCESS = "New recipe added: %1$s";
     public static final String MESSAGE_DUPLICATE_RECIPE = "This recipe already exists in the recipe book";
@@ -73,7 +73,7 @@ public class AddCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddCommand // instanceof handles nulls
-                && toAdd.equals(((AddCommand) other).toAdd));
+            || (other instanceof AddCommand // instanceof handles nulls
+            && toAdd.equals(((AddCommand) other).toAdd));
     }
 }

--- a/src/main/java/seedu/recipe/logic/commands/AddFormCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/AddFormCommand.java
@@ -11,7 +11,7 @@ import seedu.recipe.model.recipe.Recipe;
 import seedu.recipe.ui.AddRecipeForm;
 
 /**
- * Opens a new RecipeForm instance.
+ * Adds a recipe to the recipe book via a form UI.
  */
 public class AddFormCommand extends Command {
 
@@ -29,7 +29,7 @@ public class AddFormCommand extends Command {
     }
 
     /**
-     * Executes the AddFormCommand which opens a new RecipeForm instance and adds the recipe.
+     * Executes the AddFormCommand, which opens a new RecipeForm instance and adds the recipe.
      *
      * @param model The {@code Model} which the command should operate on.
      * @return A {@code CommandResult} with the message indicating the success of the operation.

--- a/src/main/java/seedu/recipe/logic/commands/AddFormCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/AddFormCommand.java
@@ -17,7 +17,7 @@ public class AddFormCommand extends Command {
 
     public static final String COMMAND_WORD = "addf";
     public static final String MESSAGE_EMPTY = "An empty form was submitted. Please enter a recipe name before "
-            + "submitting.";
+        + "submitting.";
     public static final String MESSAGE_SUCCESS = "New recipe added: %1$s";
     public static final String MESSAGE_DUPLICATE_RECIPE = "This recipe already exists in the recipe book";
     public static final String MESSAGE_PARSE_RECIPE = "This recipe could not be parsed properly.";
@@ -38,15 +38,14 @@ public class AddFormCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        StringBuilder commands = new StringBuilder();
-        AddRecipeForm recipeForm = new AddRecipeForm(commands);
+        StringBuilder data = new StringBuilder();
+        AddRecipeForm recipeForm = new AddRecipeForm(data);
         recipeForm.display();
-        String commandString = commands.toString();
 
+        String commandString = data.toString();
         if (commandString.isEmpty()) {
             throw new CommandException(MESSAGE_EMPTY);
         }
-
         try {
             RecipeDescriptor toAdd = AddCommandParser.parseToRecipeDescriptor(commandString);
             Recipe recipeToAdd = toAdd.toRecipe();

--- a/src/main/java/seedu/recipe/ui/AddRecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/AddRecipeForm.java
@@ -1,29 +1,29 @@
 package seedu.recipe.ui;
 
-//Core imports
-
 import java.util.Map;
 
 import javafx.scene.control.TextArea;
 import seedu.recipe.ui.util.FieldsUtil;
 
 /**
- * Represents the form element for users to edit {@code Recipe}s
+ * Represents the form element for users to add {@code Recipe}s
  */
 public class AddRecipeForm extends RecipeForm {
     private static final String title = "Add New Recipe";
 
     /**
-     * Creates a new RecipeForm with the given recipe and displayed index.
-     * If the recipe is not null, the form fields are pre-populated with the recipe's data.
-     *
-     * @param data The StringBuilder used to store form data.
+     * Creates a new AddRecipeForm.
      */
     public AddRecipeForm(StringBuilder data) {
         super(null, data, title);
         init();
     }
 
+    /**
+     * Initializes the AddRecipeForm.
+     * <p>
+     * Adds blank TextAreas under the Ingredient and Step boxes.
+     */
     private void init() {
         TextArea emptyIngredientField = FieldsUtil.createDynamicTextArea("");
         ingredientsBox.getChildren().add(emptyIngredientField);
@@ -32,12 +32,12 @@ public class AddRecipeForm extends RecipeForm {
     }
 
     /**
-     * Handles the edit recipe event by updating the recipe with the changed values.
+     * Handles the add recipe event by updating the recipe with the changed values.
      *
      * @param changedValues A map of the changed recipe fields with keys as field names and values as the new data.
      */
     @Override
-    public void handle(Map<String, String> changedValues) {
+    protected void handle(Map<String, String> changedValues) {
         data.append("add ");
         collectFields(changedValues);
     }

--- a/src/main/java/seedu/recipe/ui/AddRecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/AddRecipeForm.java
@@ -1,197 +1,44 @@
 package seedu.recipe.ui;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
+//Core imports
 
-import javafx.fxml.FXML;
-import javafx.scene.Scene;
-import javafx.scene.control.Button;
+import java.util.Map;
+
 import javafx.scene.control.TextArea;
-import javafx.scene.control.TextField;
-import javafx.scene.input.KeyCode;
-import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.VBox;
-import javafx.stage.Modality;
-import javafx.stage.Stage;
-import seedu.recipe.commons.core.LogsCenter;
 import seedu.recipe.ui.util.FieldsUtil;
 
 /**
- * Represents the form element for users to add {@code Recipe}s
+ * Represents the form element for users to edit {@code Recipe}s
  */
-public class AddRecipeForm extends UiPart<Region> {
-    private static final String FXML = "AddRecipeForm.fxml";
-    //Logic executors and system logging
-    private final Logger logger = LogsCenter.getLogger(getClass());
-    @FXML
-    private TextField nameField;
-    @FXML
-    private TextField durationField;
-    @FXML
-    private TextField portionField;
-    @FXML
-    private TextField tagsField;
-    @FXML
-    private FlowPane tags;
-    @FXML
-    private VBox ingredientsBox;
-    @FXML
-    private VBox stepsBox;
-    @FXML
-    private Region buttonCtrLeft;
-    @FXML
-    private Button saveButton;
-    @FXML
-    private Button cancelButton;
-    private StringBuilder commands;
+public class AddRecipeForm extends RecipeForm {
+    private static final String title = "Add New Recipe";
 
     /**
-     * Creates a new AddRecipeForm instance.
+     * Creates a new RecipeForm with the given recipe and displayed index.
+     * If the recipe is not null, the form fields are pre-populated with the recipe's data.
      *
-     * @param commandString The {@code StringBuilder} that stores the command string.
+     * @param data The StringBuilder used to store form data.
      */
-    public AddRecipeForm(StringBuilder commandString) {
-        super(FXML);
-        this.commands = commandString;
+    public AddRecipeForm(StringBuilder data) {
+        super(null, data, title);
+        init();
+    }
+
+    private void init() {
         TextArea emptyIngredientField = FieldsUtil.createDynamicTextArea("");
         ingredientsBox.getChildren().add(emptyIngredientField);
         TextArea emptyStepField = FieldsUtil.createDynamicTextArea("");
         stepsBox.getChildren().add(emptyStepField);
-
-        HBox.setHgrow(buttonCtrLeft, Priority.ALWAYS);
-        saveButton.setOnAction(event -> saveRecipe());
-        cancelButton.setOnAction(event -> closeForm());
     }
 
     /**
-     * Saves the changes made to the recipe and closes the form.
-     * If any fields have been modified, the new values are stored
-     * in a map of added values.
-     */
-    private void saveRecipe() {
-        // Check which fields have been added
-        Map<String, String> inputValues = new HashMap<>();
-
-        inputValues.put("name", nameField.getText());
-        if (!durationField.getText().isEmpty()) {
-            inputValues.put("duration", durationField.getText());
-        }
-        if (!portionField.getText().isEmpty()) {
-            inputValues.put("portion", portionField.getText());
-        }
-        String ingredientsValue = ingredientsBox.getChildren().stream()
-            .map(node -> ((TextArea) node).getText())
-            .collect(Collectors.joining(", "));
-        if (!ingredientsValue.isEmpty()) {
-            inputValues.put("ingredients", ingredientsValue);
-        }
-
-        String stepsValue = stepsBox.getChildren().stream()
-            .map(node -> ((TextArea) node).getText())
-            .collect(Collectors.joining(", "));
-        if (!stepsValue.isEmpty()) {
-            inputValues.put("steps", stepsValue);
-        }
-
-        if (!tagsField.getText().isEmpty()) {
-            inputValues.put("tags", tagsField.getText());
-        }
-        this.commands = handleAddRecipeEvent(inputValues);
-        closeForm();
-    }
-
-    /**
-     * Handles the add recipe event.
+     * Handles the edit recipe event by updating the recipe with the changed values.
      *
-     * @param inputValues A map of the added recipe fields with keys as field names and values as the new data.
-     * @return commands The StringBuilder instance containing the command string, to be passed back to saveRecipe().
+     * @param changedValues A map of the changed recipe fields with keys as field names and values as the new data.
      */
-    private StringBuilder handleAddRecipeEvent(Map<String, String> inputValues) {
-        commands.append("add");
-        // Check if the name has been added and append the name prefix and value.
-        if (inputValues.containsKey("name")) {
-            commands.append(" n/");
-            commands.append(inputValues.get("name"));
-        }
-
-        // Check if the duration has been added and append the duration prefix and value.
-        if (inputValues.containsKey("duration")) {
-            commands.append(" d/");
-            commands.append(inputValues.get("duration"));
-        }
-
-        // Check if the portion has been added and append the duration prefix and value.
-        if (inputValues.containsKey("portion")) {
-            commands.append(" p/");
-            commands.append(inputValues.get("portion"));
-        }
-
-        // Check if the ingredients have been added and append the ingredients prefix and value.
-        if (inputValues.containsKey("ingredients")) {
-            String[] ingredients = inputValues.get("ingredients").split(", ");
-            for (String ingredient : ingredients) {
-                commands.append(" i/");
-                commands.append(ingredient);
-            }
-        }
-
-        // Check if the steps have been added and append the steps prefix and value.
-        if (inputValues.containsKey("steps")) {
-            String[] steps = inputValues.get("steps").split(", ");
-            for (String step : steps) {
-                commands.append(" s/");
-                commands.append(step);
-            }
-        }
-
-        // Check if the tags have been added and append the tags prefix and value.
-        if (inputValues.containsKey("tags")) {
-            String[] tags = inputValues.get("tags").split(", ");
-            for (String tag : tags) {
-                commands.append(" t/");
-                commands.append(tag);
-            }
-        }
-        return commands;
-    }
-
-    /**
-     * Closes the form without saving any changes.
-     */
-    private void closeForm() {
-        Stage stage = (Stage) saveButton.getScene().getWindow();
-        stage.close();
-    }
-
-    /**
-     * Displays the form in a new window.
-     * The window's title will be "Add Recipe" if creating a new recipe,
-     * or "Edit Recipe" if editing an existing recipe.
-     */
-    public void display() {
-        Stage window = new Stage();
-        // Ensures users do not exit the view by clicking outside
-        window.initModality(Modality.APPLICATION_MODAL);
-        window.setTitle("Add Recipe");
-
-        //Individual elements
-        Scene scene = new Scene(getRoot());
-        scene.setOnKeyPressed(event -> {
-            if (event.getCode() == KeyCode.ESCAPE) {
-                window.close();
-            }
-        });
-        window.setScene(scene);
-        window.showAndWait();
-    }
-
-    @FunctionalInterface
-    interface CustomFocusChangeListener {
-        void onFocusChange(boolean newValue);
+    @Override
+    public void handle(Map<String, String> changedValues) {
+        data.append("add ");
+        collectFields(changedValues);
     }
 }

--- a/src/main/java/seedu/recipe/ui/EditRecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/EditRecipeForm.java
@@ -15,11 +15,6 @@ public class EditRecipeForm extends RecipeForm {
 
     /**
      * Creates a new EditRecipeForm with the given recipe and displayed index.
-     * If the recipe is not null, the form fields are pre-populated with the recipe's data.
-     *
-     * @param data   The StringBuilder used to store form data.
-     * @param recipe The recipe to edit or null for creating a new recipe.
-     * @param index  The index of the recipe in the displayed list.
      */
     public EditRecipeForm(Recipe recipe, int index, StringBuilder data) {
         super(recipe, data, title);
@@ -32,7 +27,7 @@ public class EditRecipeForm extends RecipeForm {
      * @param changedValues A map of the changed recipe fields with keys as field names and values as the new data.
      */
     @Override
-    public void handle(Map<String, String> changedValues) {
+    protected void handle(Map<String, String> changedValues) {
         data.append("edit ");
         data.append(index);
         collectFields(changedValues);

--- a/src/main/java/seedu/recipe/ui/EditRecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/EditRecipeForm.java
@@ -14,9 +14,10 @@ public class EditRecipeForm extends RecipeForm {
     private final int index;
 
     /**
-     * Creates a new RecipeForm with the given recipe and displayed index.
+     * Creates a new EditRecipeForm with the given recipe and displayed index.
      * If the recipe is not null, the form fields are pre-populated with the recipe's data.
      *
+     * @param data   The StringBuilder used to store form data.
      * @param recipe The recipe to edit or null for creating a new recipe.
      * @param index  The index of the recipe in the displayed list.
      */

--- a/src/main/java/seedu/recipe/ui/EditRecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/EditRecipeForm.java
@@ -1,0 +1,39 @@
+package seedu.recipe.ui;
+
+//Core imports
+
+import java.util.Map;
+
+import seedu.recipe.model.recipe.Recipe;
+
+/**
+ * Represents the form element for users to edit {@code Recipe}s
+ */
+public class EditRecipeForm extends RecipeForm {
+    private static final String title = "Edit Recipe";
+    private final int index;
+
+    /**
+     * Creates a new RecipeForm with the given recipe and displayed index.
+     * If the recipe is not null, the form fields are pre-populated with the recipe's data.
+     *
+     * @param recipe The recipe to edit or null for creating a new recipe.
+     * @param index  The index of the recipe in the displayed list.
+     */
+    public EditRecipeForm(Recipe recipe, int index, StringBuilder data) {
+        super(recipe, data, title);
+        this.index = index;
+    }
+
+    /**
+     * Handles the edit recipe event by updating the recipe with the changed values.
+     *
+     * @param changedValues A map of the changed recipe fields with keys as field names and values as the new data.
+     */
+    @Override
+    public void handle(Map<String, String> changedValues) {
+        data.append("edit ");
+        data.append(index);
+        collectFields(changedValues);
+    }
+}

--- a/src/main/java/seedu/recipe/ui/MainWindow.java
+++ b/src/main/java/seedu/recipe/ui/MainWindow.java
@@ -1,5 +1,8 @@
 package seedu.recipe.ui;
 
+import static seedu.recipe.ui.events.DeleteRecipeEvent.DELETE_RECIPE_EVENT_TYPE;
+import static seedu.recipe.ui.events.EditRecipeEvent.EDIT_RECIPE_EVENT_TYPE;
+
 import java.io.IOException;
 import java.util.logging.Logger;
 
@@ -24,6 +27,7 @@ import seedu.recipe.model.recipe.Recipe;
 import seedu.recipe.storage.ExportManager;
 import seedu.recipe.storage.ImportManager;
 import seedu.recipe.ui.events.DeleteRecipeEvent;
+import seedu.recipe.ui.events.EditRecipeEvent;
 
 /**
  * Represents the main window of the application. This class is responsible for
@@ -39,6 +43,7 @@ public class MainWindow extends UiPart<Stage> {
     private final Stage primaryStage;
     private final Logic logic;
     private final HelpWindow helpWindow;
+
 
     // Independent Ui parts residing in this Ui container
     private RecipeListPanel recipeListPanel;
@@ -66,7 +71,7 @@ public class MainWindow extends UiPart<Stage> {
      * Initializes and configures the UI components.
      *
      * @param primaryStage the primary stage for this main window.
-     * @param logic the main logic instance of the application.
+     * @param logic        the main logic instance of the application.
      */
     public MainWindow(Stage primaryStage, Logic logic) {
         super(FXML, primaryStage);
@@ -85,7 +90,8 @@ public class MainWindow extends UiPart<Stage> {
 
         //setAccelerator(importMenuItem, KeyCombination.valueOf("F2"));
 
-        getRoot().addEventFilter(DeleteRecipeEvent.DELETE_RECIPE_EVENT_TYPE, this::handleDeleteRecipeEvent);
+        getRoot().addEventFilter(DELETE_RECIPE_EVENT_TYPE, this::handleDeleteRecipeEvent);
+        getRoot().addEventFilter(EDIT_RECIPE_EVENT_TYPE, this::handleEditRecipeEvent);
 
         helpWindow = new HelpWindow();
     }
@@ -183,6 +189,21 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Handles the EditRecipeEvent by executing the appropriate edit command
+     * based on the provided command string.
+     *
+     * @param event the EditRecipeEvent containing the command string to be executed.
+     */
+    private void handleEditRecipeEvent(EditRecipeEvent event) {
+        String commandText = event.getCommandText();
+        try {
+            executeCommand(commandText);
+        } catch (CommandException | ParseException e) {
+            logger.info("Failed to edit recipe with command: " + commandText);
+        }
+    }
+
+    /**
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
@@ -222,6 +243,7 @@ public class MainWindow extends UiPart<Stage> {
             helpWindow.focus();
         }
     }
+
     /**
      * Renders the primary stage of this main window visible.
      */
@@ -235,7 +257,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleExit() {
         GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                                                  (int) primaryStage.getX(), (int) primaryStage.getY());
+            (int) primaryStage.getX(), (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();
@@ -257,7 +279,7 @@ public class MainWindow extends UiPart<Stage> {
      * @param commandText the command text to execute.
      * @return the resulting {@code CommandResult} after executing the command.
      * @throws CommandException if the command execution fails.
-     * @throws ParseException if the command text cannot be parsed.
+     * @throws ParseException   if the command text cannot be parsed.
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {

--- a/src/main/java/seedu/recipe/ui/RecipeCard.java
+++ b/src/main/java/seedu/recipe/ui/RecipeCard.java
@@ -25,6 +25,7 @@ import seedu.recipe.model.tag.Tag;
 import seedu.recipe.model.util.IngredientUtil;
 import seedu.recipe.ui.CommandBox.CommandExecutor;
 import seedu.recipe.ui.events.DeleteRecipeEvent;
+import seedu.recipe.ui.events.EditRecipeEvent;
 
 
 /**
@@ -137,8 +138,11 @@ public class RecipeCard extends UiPart<Region> {
                 popup.display();
             } else if (event.getCode() == KeyCode.F) {
                 try {
-                    RecipeForm form = new RecipeForm(recipe, displayedIndex, commandExecutor);
+                    StringBuilder data = new StringBuilder();
+                    RecipeForm form = new RecipeForm(recipe, displayedIndex, commandExecutor, data);
                     form.display();
+                    EditRecipeEvent editEvent = new EditRecipeEvent(data.toString());
+                    cardPane.fireEvent(editEvent);
                 } catch (Exception e) {
                     // catch-em-all is bad!
                     System.out.println(e);

--- a/src/main/java/seedu/recipe/ui/RecipeCard.java
+++ b/src/main/java/seedu/recipe/ui/RecipeCard.java
@@ -139,7 +139,7 @@ public class RecipeCard extends UiPart<Region> {
             } else if (event.getCode() == KeyCode.F) {
                 // create and display form
                 StringBuilder data = new StringBuilder();
-                RecipeForm form = new RecipeForm(recipe, displayedIndex, data);
+                EditRecipeForm form = new EditRecipeForm(recipe, displayedIndex, data);
                 form.display();
 
                 // trigger EditRecipeEvent with form data

--- a/src/main/java/seedu/recipe/ui/RecipeCard.java
+++ b/src/main/java/seedu/recipe/ui/RecipeCard.java
@@ -137,15 +137,16 @@ public class RecipeCard extends UiPart<Region> {
                 RecipePopup popup = new RecipePopup(recipe, displayedIndex);
                 popup.display();
             } else if (event.getCode() == KeyCode.F) {
-                try {
-                    StringBuilder data = new StringBuilder();
-                    RecipeForm form = new RecipeForm(recipe, displayedIndex, commandExecutor, data);
-                    form.display();
-                    EditRecipeEvent editEvent = new EditRecipeEvent(data.toString());
+                // create and display form
+                StringBuilder data = new StringBuilder();
+                RecipeForm form = new RecipeForm(recipe, displayedIndex, data);
+                form.display();
+
+                // trigger EditRecipeEvent with form data
+                String commandText = data.toString();
+                if (!commandText.isEmpty()) {
+                    EditRecipeEvent editEvent = new EditRecipeEvent(commandText);
                     cardPane.fireEvent(editEvent);
-                } catch (Exception e) {
-                    // catch-em-all is bad!
-                    System.out.println(e);
                 }
             }
         });

--- a/src/main/java/seedu/recipe/ui/RecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/RecipeForm.java
@@ -45,6 +45,7 @@ public class RecipeForm extends UiPart<Region> {
     //Logic executors and system logging
     private final CommandExecutor commandExecutor;
     private final Logger logger = LogsCenter.getLogger(getClass());
+    private final StringBuilder data;
     //UI child elements
     @FXML
     private TextField nameField;
@@ -76,11 +77,12 @@ public class RecipeForm extends UiPart<Region> {
      * @param recipe         The recipe to edit or null for creating a new recipe.
      * @param displayedIndex The index of the recipe in the displayed list.
      */
-    public RecipeForm(Recipe recipe, int displayedIndex, CommandExecutor commandExecutor) {
+    public RecipeForm(Recipe recipe, int displayedIndex, CommandExecutor commandExecutor, StringBuilder data) {
         super(FXML);
         this.recipe = recipe;
         this.commandExecutor = commandExecutor;
         this.displayedIndex = displayedIndex;
+        this.data = data;
         if (recipe != null) {
             populateFields();
         }
@@ -219,13 +221,13 @@ public class RecipeForm extends UiPart<Region> {
             Optional.ofNullable(recipe.getDurationNullable())
                 .map(Object::toString)
                 .orElse("")
-        );
+                             );
         //Portion
         portionField.setText(
             Optional.ofNullable(recipe.getPortionNullable())
                 .map(Object::toString)
                 .orElse("")
-        );
+                            );
 
         //Ingredients
         if (!recipe.getIngredients().isEmpty()) {
@@ -343,18 +345,14 @@ public class RecipeForm extends UiPart<Region> {
      * @param changedValues A map of the changed recipe fields with keys as field names and values as the new data.
      */
     private void handleEditRecipeEvent(int index, Map<String, String> changedValues) {
-        try {
-            StringBuilder commands = new StringBuilder();
+        StringBuilder commands = new StringBuilder();
 
-            // Add the index of the item to edit.
-            commands.append(index);
-            commands = collectFields(commands, changedValues);
-            String commandText = "edit " + commands.toString();
+        // Add the index of the item to edit.
+        commands.append(index);
+        commands = collectFields(commands, changedValues);
+        String commandText = "edit " + commands.toString();
 
-            executeCommand(commandText);
-        } catch (CommandException | ParseException e) {
-            logger.info("Failed to edit recipe: " + index);
-        }
+        data.append(commandText);
     }
 
     /**

--- a/src/main/java/seedu/recipe/ui/RecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/RecipeForm.java
@@ -1,7 +1,5 @@
 package seedu.recipe.ui;
 
-//Core imports
-
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +12,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -27,7 +24,7 @@ import seedu.recipe.model.recipe.ingredient.IngredientBuilder;
 import seedu.recipe.ui.util.FieldsUtil;
 
 /**
- * Represents the form element for users to edit {@code Recipe}s
+ * Represents a generic form element for modifying {@code Recipe}s.
  */
 public abstract class RecipeForm extends UiPart<Region> {
     // constants
@@ -45,6 +42,7 @@ public abstract class RecipeForm extends UiPart<Region> {
     protected VBox ingredientsBox;
     @FXML
     protected VBox stepsBox;
+
     //UI child elements
     @FXML
     private TextField nameField;
@@ -54,8 +52,7 @@ public abstract class RecipeForm extends UiPart<Region> {
     private TextField portionField;
     @FXML
     private TextField tagsField;
-    @FXML
-    private FlowPane tags;
+
     //Core CTA Group
     @FXML
     private Region buttonCtrLeft;
@@ -65,10 +62,12 @@ public abstract class RecipeForm extends UiPart<Region> {
     private Button cancelButton;
 
     /**
-     * Creates a new RecipeForm with the given recipe and displayed index.
-     * If the recipe is not null, the form fields are pre-populated with the recipe's data.
+     * Creates a new RecipeForm with a given recipe and a StringBuilder to store data in.
+     * If the recipe is not null, the form fields are pre-populated with the given recipe's data.
      *
-     * @param recipe The recipe to edit or null for creating a new recipe.
+     * @param data   The StringBuilder used to store form data.
+     * @param recipe The given recipe to seed form data with.
+     * @param title  The title of the form window.
      */
     public RecipeForm(Recipe recipe, StringBuilder data, String title) {
         super(FXML);
@@ -148,7 +147,7 @@ public abstract class RecipeForm extends UiPart<Region> {
     }
 
     /**
-     * Closes the form without saving any changes.
+     * Closes the form window.
      */
     private void closeForm() {
         Stage stage = (Stage) saveButton.getScene().getWindow();
@@ -156,12 +155,11 @@ public abstract class RecipeForm extends UiPart<Region> {
     }
 
     /**
-     * Displays the form in a new window.
-     * The window's title will be "Add Recipe" if creating a new recipe,
-     * or "Edit Recipe" if editing an existing recipe.
+     * Displays the form by creating a new window.
      */
     public void display() {
         Stage window = new Stage();
+
         // Ensures users do not exit the view by clicking outside
         window.initModality(Modality.APPLICATION_MODAL);
         window.setTitle(title);
@@ -187,8 +185,6 @@ public abstract class RecipeForm extends UiPart<Region> {
 
     /**
      * Stores the initial values of the form fields in a HashMap.
-     * This is used for comparison when saving the recipe to determine
-     * which fields have been changed.
      */
     private void storeInitialValues() {
         initialValues.put("name", nameField.getText().trim());
@@ -209,8 +205,7 @@ public abstract class RecipeForm extends UiPart<Region> {
     // The following functions are helper functions used in the main code above.
 
     /**
-     * Populates the form fields with the data from the existing recipe.
-     * Stores all prepopulated data into a hashmap for comparison later when saving.
+     * Populates the form fields with the data from the seed recipe.
      */
     private void populateFields() {
         nameField.setText(recipe.getName().recipeName);
@@ -266,11 +261,11 @@ public abstract class RecipeForm extends UiPart<Region> {
     }
 
     /**
-     * Helper method to add all the changed field data into an existing StringBuilder instance.
+     * Stores changed recipe fields into the data StringBuilder.
      *
      * @param changedValues A map of the changed recipe fields with keys as field names and values as the new data.
      */
-    public void collectFields(Map<String, String> changedValues) {
+    protected void collectFields(Map<String, String> changedValues) {
         // Check if the name has been changed and append the name prefix and value.
         if (changedValues.containsKey("name")) {
             data.append(" n/");
@@ -317,5 +312,10 @@ public abstract class RecipeForm extends UiPart<Region> {
         }
     }
 
-    public abstract void handle(Map<String, String> changedValues);
+    /**
+     * Processes the data in the form for use externally.
+     *
+     * @param changedValues A map of the changed recipe fields with keys as field names and values as the new data.
+     */
+    protected abstract void handle(Map<String, String> changedValues);
 }

--- a/src/main/java/seedu/recipe/ui/RecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/RecipeForm.java
@@ -32,16 +32,17 @@ public abstract class RecipeForm extends UiPart<Region> {
     private static final String INGREDIENT_PROMPT = "(i.e. `a/100 g n/parmesan cheese r/grated s/mozzarella`";
     private static final double DEFAULT_HEIGHT = 500;
 
-    // data fields
+    // protected fields for package access
     protected final StringBuilder data;
-
-    private final Recipe recipe;
-    private final Map<String, String> initialValues = new HashMap<>();
-    private final String title;
     @FXML
     protected VBox ingredientsBox;
     @FXML
     protected VBox stepsBox;
+
+    //data fields
+    private final Recipe recipe;
+    private final Map<String, String> initialValues = new HashMap<>();
+    private final String title;
 
     //UI child elements
     @FXML
@@ -214,13 +215,13 @@ public abstract class RecipeForm extends UiPart<Region> {
             Optional.ofNullable(recipe.getDurationNullable())
                 .map(Object::toString)
                 .orElse("")
-                             );
+        );
         //Portion
         portionField.setText(
             Optional.ofNullable(recipe.getPortionNullable())
                 .map(Object::toString)
                 .orElse("")
-                            );
+        );
 
         //Ingredients
         if (!recipe.getIngredients().isEmpty()) {

--- a/src/main/java/seedu/recipe/ui/RecipeForm.java
+++ b/src/main/java/seedu/recipe/ui/RecipeForm.java
@@ -41,7 +41,10 @@ public abstract class RecipeForm extends UiPart<Region> {
     private final Recipe recipe;
     private final Map<String, String> initialValues = new HashMap<>();
     private final String title;
-
+    @FXML
+    protected VBox ingredientsBox;
+    @FXML
+    protected VBox stepsBox;
     //UI child elements
     @FXML
     private TextField nameField;
@@ -53,10 +56,6 @@ public abstract class RecipeForm extends UiPart<Region> {
     private TextField tagsField;
     @FXML
     private FlowPane tags;
-    @FXML
-    private VBox ingredientsBox;
-    @FXML
-    private VBox stepsBox;
     //Core CTA Group
     @FXML
     private Region buttonCtrLeft;

--- a/src/main/java/seedu/recipe/ui/events/EditRecipeEvent.java
+++ b/src/main/java/seedu/recipe/ui/events/EditRecipeEvent.java
@@ -1,7 +1,5 @@
 package seedu.recipe.ui.events;
 
-import java.util.Map;
-
 import javafx.event.Event;
 import javafx.event.EventType;
 
@@ -16,47 +14,21 @@ public class EditRecipeEvent extends Event {
      */
     public static final EventType<EditRecipeEvent> EDIT_RECIPE_EVENT_TYPE = new EventType<>(Event.ANY, "EDIT_RECIPE");
 
-    /**
-     * The index of the recipe to be edited.
-     */
-    private final int recipeIndex;
-
-    /**
-     * A map of the changed values, where the keys are the field names and
-     * the values are the updated field values.
-     */
-    private final Map<String, String> changedValues;
+    private final String commandText;
 
     /**
      * Constructs an EditRecipeEvent with the EDIT_RECIPE_EVENT_TYPE,
      * specified recipe index, and the map of changed values.
      *
-     * @param recipeIndex The index of the recipe to be edited.
-     * @param changedValues A map of the changed values, with field names as keys
-     *                      and updated field values as values.
+     * @param commandText String representation of the Edit command to be executed.
      */
-    public EditRecipeEvent(int recipeIndex, Map<String, String> changedValues) {
+    public EditRecipeEvent(String commandText) {
         super(EDIT_RECIPE_EVENT_TYPE);
-        this.recipeIndex = recipeIndex;
-        this.changedValues = changedValues;
+        this.commandText = commandText;
     }
 
-    /**
-     * Retrieves the index of the recipe to be edited.
-     *
-     * @return The index of the recipe to be edited.
-     */
-    public int getRecipeIndex() {
-        return recipeIndex;
+    public String getCommandText() {
+        return commandText;
     }
 
-    /**
-     * Retrieves the map of changed values, with field names as keys
-     * and updated field values as values.
-     *
-     * @return The map of changed values.
-     */
-    public Map<String, String> getChangedValues() {
-        return changedValues;
-    }
 }

--- a/src/main/java/seedu/recipe/ui/util/FieldsUtil.java
+++ b/src/main/java/seedu/recipe/ui/util/FieldsUtil.java
@@ -26,12 +26,12 @@ public class FieldsUtil {
     public static TextArea createDynamicTextArea(String text) {
         //Styling
         TextArea textArea = new TextArea(text);
-        //textArea.setWrapText(true);
-        //textArea.setMaxHeight(0.0);
-        //textArea.setPrefHeight(5.0);
-        //Keyboard listener for navigation
+
         textArea.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (event.getCode() == KeyCode.BACK_SPACE) {
+            if (event.getCode() == KeyCode.BACK_SPACE
+                    || event.getCode() == KeyCode.LEFT
+                    || event.getCode() == KeyCode.RIGHT
+            ) {
                 return;
             }
             int currentIndex = ((VBox) textArea.getParent()).getChildren().indexOf(textArea);

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -119,7 +119,7 @@
 }
 
 .list-cell:filled:selected {
-    -fx-background-color: #3f3f46;
+    -fx-background-color: #475569;
 }
 
 .list-cell:filled:selected #cardPane {


### PR DESCRIPTION
**motivation**
- add and edit forms share a lot of similar functionality, but are implemented in separate places -> code duplication -> bad code quality
- both forms also have their own (similar) logic to convert form data into a command
- validation logic is quite weak rn and affects usability (see above screenshot for issues with edit form) -> refactor puts data-to-command logic in one place -> easier to implement validation on the new unified data-to-command logic
- edit form currently holds onto a commandExecutor and executes the edit command itself, instead of going through MainWindow as all commands should -> bad abstraction

**proposed implementation**
- similar to the add form, pass a StringBuilder when constructing edit form
- edit form populates the stringbuilder then exits
- due to the form being a blocking call, we can read the stringbuilder data within RecipeCard and use that to fire off a custom EditRecipeEvent
- MainWindow picks up EditRecipeEvent and handles it by executing the command itself (similar to the way the recipecard delete event currently works)