### PR TITLE
V1.4: Fix Logic bugs

### DIFF
--- a/src/main/java/seedu/recipe/logic/commands/AddFormCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/AddFormCommand.java
@@ -55,7 +55,7 @@ public class AddFormCommand extends Command {
             model.addRecipe(recipeToAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, recipeToAdd.getName()));
         } catch (ParseException e) {
-            throw new CommandException(MESSAGE_PARSE_RECIPE);
+            throw new CommandException(e.getMessage());
         }
     }
 }

--- a/src/main/java/seedu/recipe/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/AddCommandParser.java
@@ -8,20 +8,11 @@ import static seedu.recipe.logic.parser.CliSyntax.PREFIX_PORTION;
 import static seedu.recipe.logic.parser.CliSyntax.PREFIX_STEP;
 import static seedu.recipe.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.recipe.logic.commands.AddCommand;
 import seedu.recipe.logic.parser.exceptions.ParseException;
-import seedu.recipe.logic.parser.functional.TryUtil;
 import seedu.recipe.logic.util.RecipeDescriptor;
-import seedu.recipe.model.recipe.Name;
-import seedu.recipe.model.recipe.Step;
-import seedu.recipe.model.recipe.ingredient.Ingredient;
-import seedu.recipe.model.recipe.ingredient.IngredientInformation;
-import seedu.recipe.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -48,39 +39,11 @@ public class AddCommandParser implements Parser<AddCommand> {
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PORTION, PREFIX_DURATION,
                 PREFIX_TAG, PREFIX_INGREDIENT, PREFIX_STEP);
 
+        // validate input
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
-        RecipeDescriptor recipeDescriptor = new RecipeDescriptor();
-
-        // we call Optional<Name>::get here without checking ifPresent
-        // this is safe since we already check if a Name argument is present
-        //noinspection OptionalGetWithoutIsPresent
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        recipeDescriptor.setName(name);
-
-        // 1. Parse Duration
-        argMultimap.getValue(PREFIX_DURATION)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
-            .ifPresent(recipeDescriptor::setDuration);
-
-        // 2. Parse Portion
-        argMultimap.getValue(PREFIX_PORTION)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
-            .ifPresent(recipeDescriptor::setPortion);
-
-        // 3. Parse Tags
-        Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        recipeDescriptor.setTags(tags);
-
-        // 4. Parse Ingredients
-        HashMap<Ingredient, IngredientInformation> ingredientTable = ParserUtil.parseIngredients(
-            argMultimap.getAllValues(PREFIX_INGREDIENT));
-        recipeDescriptor.setIngredients(ingredientTable);
-
-        // 5. Parse Steps
-        List<Step> steps = ParserUtil.parseSteps(argMultimap.getAllValues(PREFIX_STEP));
-        recipeDescriptor.setSteps(steps);
+        RecipeDescriptor recipeDescriptor = ParserUtil.parseToRecipeDescriptor(argMultimap);
         return recipeDescriptor;
     }
 

--- a/src/main/java/seedu/recipe/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/AddCommandParser.java
@@ -20,7 +20,6 @@ import seedu.recipe.logic.util.RecipeDescriptor;
 import seedu.recipe.model.recipe.Name;
 import seedu.recipe.model.recipe.Step;
 import seedu.recipe.model.recipe.ingredient.Ingredient;
-import seedu.recipe.model.recipe.ingredient.IngredientBuilder;
 import seedu.recipe.model.recipe.ingredient.IngredientInformation;
 import seedu.recipe.model.tag.Tag;
 
@@ -37,17 +36,6 @@ public class AddCommandParser implements Parser<AddCommand> {
     }
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
-     *
-     * @throws ParseException if the user input does not conform the expected format
-     */
-    public AddCommand parse(String args) throws ParseException {
-        RecipeDescriptor recipeDescriptor = parseToRecipeDescriptor(args);
-        return new AddCommand(recipeDescriptor);
-    }
-
-    /**
      * Generates a RecipeDescriptor object based on the string input by the user,
      * which we then use to create a new AddCommand object.
      *
@@ -58,7 +46,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public static RecipeDescriptor parseToRecipeDescriptor(String args) throws ParseException {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PORTION, PREFIX_DURATION,
-                                   PREFIX_TAG, PREFIX_INGREDIENT, PREFIX_STEP);
+                PREFIX_TAG, PREFIX_INGREDIENT, PREFIX_STEP);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
@@ -73,27 +61,37 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         // 1. Parse Duration
         argMultimap.getValue(PREFIX_DURATION)
-                .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
-                .ifPresent(recipeDescriptor::setDuration);
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
+            .ifPresent(recipeDescriptor::setDuration);
 
         // 2. Parse Portion
         argMultimap.getValue(PREFIX_PORTION)
-                .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
-                .ifPresent(recipeDescriptor::setPortion);
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
+            .ifPresent(recipeDescriptor::setPortion);
 
         // 3. Parse Tags
         Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         recipeDescriptor.setTags(tags);
 
         // 4. Parse Ingredients
-        List<IngredientBuilder> ingredients = ParserUtil.parseIngredients(argMultimap.getAllValues(PREFIX_INGREDIENT));
-        HashMap<Ingredient, IngredientInformation> ingredientTable = new HashMap<>();
-        ingredients.forEach(ingredientBuilder -> ingredientTable.putAll(ingredientBuilder.build()));
+        HashMap<Ingredient, IngredientInformation> ingredientTable = ParserUtil.parseIngredients(
+            argMultimap.getAllValues(PREFIX_INGREDIENT));
         recipeDescriptor.setIngredients(ingredientTable);
 
         // 5. Parse Steps
         List<Step> steps = ParserUtil.parseSteps(argMultimap.getAllValues(PREFIX_STEP));
         recipeDescriptor.setSteps(steps);
         return recipeDescriptor;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddCommand parse(String args) throws ParseException {
+        RecipeDescriptor recipeDescriptor = parseToRecipeDescriptor(args);
+        return new AddCommand(recipeDescriptor);
     }
 }

--- a/src/main/java/seedu/recipe/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/recipe/logic/parser/ArgumentMultimap.java
@@ -54,6 +54,16 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Checks if the given {@code prefix} exists in this ArgumentMultimap.
+     *
+     * @param prefix Prefix to check.
+     * @return Whether the given prefix exists.
+     */
+    public boolean containsKey(Prefix prefix) {
+        return argMultimap.containsKey(prefix);
+    }
+
+    /**
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {

--- a/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
@@ -37,7 +37,6 @@ public class EditCommandParser implements Parser<EditCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
-        System.out.println("args: " + args);
         requireNonNull(args);
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DURATION, PREFIX_PORTION,

--- a/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.recipe.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,7 +22,8 @@ import seedu.recipe.logic.parser.exceptions.ParseException;
 import seedu.recipe.logic.parser.functional.TryUtil;
 import seedu.recipe.logic.util.RecipeDescriptor;
 import seedu.recipe.model.recipe.Step;
-import seedu.recipe.model.recipe.ingredient.IngredientBuilder;
+import seedu.recipe.model.recipe.ingredient.Ingredient;
+import seedu.recipe.model.recipe.ingredient.IngredientInformation;
 import seedu.recipe.model.tag.Tag;
 
 /**
@@ -38,8 +40,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DURATION, PREFIX_PORTION,
-                                           PREFIX_TAG, PREFIX_INGREDIENT, PREFIX_STEP);
+            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DURATION, PREFIX_PORTION,
+                PREFIX_TAG, PREFIX_INGREDIENT, PREFIX_STEP);
         Index index;
 
         try {
@@ -51,25 +53,25 @@ public class EditCommandParser implements Parser<EditCommand> {
         RecipeDescriptor recipeDescriptor = new RecipeDescriptor();
 
         argMultimap.getValue(PREFIX_NAME)
-                .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseName, s))
-                .ifPresent(recipeDescriptor::setName);
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseName, s))
+            .ifPresent(recipeDescriptor::setName);
 
         argMultimap.getValue(PREFIX_DURATION)
-                .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
-                .ifPresent(recipeDescriptor::setDuration);
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
+            .ifPresent(recipeDescriptor::setDuration);
 
         argMultimap.getValue(PREFIX_PORTION)
-                .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
-                .ifPresent(recipeDescriptor::setPortion);
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
+            .ifPresent(recipeDescriptor::setPortion);
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG))
-                .ifPresent(recipeDescriptor::setTags);
+            .ifPresent(recipeDescriptor::setTags);
 
         parseIngredientsForEdit(argMultimap.getAllValues(PREFIX_INGREDIENT))
-                .ifPresent(recipeDescriptor::setIngredients);
+            .ifPresent(recipeDescriptor::setIngredients);
 
         parseStepsForEdit(argMultimap.getAllValues(PREFIX_STEP))
-                .ifPresent(recipeDescriptor::setSteps);
+            .ifPresent(recipeDescriptor::setSteps);
 
         if (!recipeDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -93,17 +95,17 @@ public class EditCommandParser implements Parser<EditCommand> {
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
-    private Optional<List<IngredientBuilder>> parseIngredientsForEdit(
-            Collection<String> ingredients) throws ParseException {
+    private Optional<HashMap<Ingredient, IngredientInformation>> parseIngredientsForEdit(
+        Collection<String> ingredients) throws ParseException {
         assert ingredients != null;
 
         if (ingredients.isEmpty()) {
             return Optional.empty();
         }
         Collection<String> ingredientList =
-                ingredients.size() == 1 && ingredients.contains("")
-                        ? Collections.emptyList()
-                        : ingredients;
+            ingredients.size() == 1 && ingredients.contains("")
+                ? Collections.emptyList()
+                : ingredients;
         return Optional.of(ParserUtil.parseIngredients(ingredientList));
     }
 

--- a/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditCommandParser.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import seedu.recipe.commons.core.index.Index;
 import seedu.recipe.logic.commands.EditCommand;
 import seedu.recipe.logic.parser.exceptions.ParseException;
-import seedu.recipe.logic.parser.functional.TryUtil;
 import seedu.recipe.logic.util.RecipeDescriptor;
 import seedu.recipe.model.recipe.Step;
 import seedu.recipe.model.recipe.ingredient.Ingredient;
@@ -38,6 +37,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
+        System.out.println("args: " + args);
         requireNonNull(args);
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DURATION, PREFIX_PORTION,
@@ -50,28 +50,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        RecipeDescriptor recipeDescriptor = new RecipeDescriptor();
-
-        argMultimap.getValue(PREFIX_NAME)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseName, s))
-            .ifPresent(recipeDescriptor::setName);
-
-        argMultimap.getValue(PREFIX_DURATION)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
-            .ifPresent(recipeDescriptor::setDuration);
-
-        argMultimap.getValue(PREFIX_PORTION)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
-            .ifPresent(recipeDescriptor::setPortion);
-
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG))
-            .ifPresent(recipeDescriptor::setTags);
-
-        parseIngredientsForEdit(argMultimap.getAllValues(PREFIX_INGREDIENT))
-            .ifPresent(recipeDescriptor::setIngredients);
-
-        parseStepsForEdit(argMultimap.getAllValues(PREFIX_STEP))
-            .ifPresent(recipeDescriptor::setSteps);
+        RecipeDescriptor recipeDescriptor = ParserUtil.parseToRecipeDescriptor(argMultimap);
 
         if (!recipeDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -210,14 +210,26 @@ public class ParserUtil {
 
         Optional<String> durationString = argMultimap.getValue(PREFIX_DURATION);
         if (durationString.isPresent()) {
-            RecipeDuration duration = parseDuration(durationString.get());
+            RecipeDuration duration = null;
+            // handle the case where empty duration string is provided
+            // interpret this as: user wants to clear the duration field
+            if (!durationString.get().equals("")) {
+                duration = parseDuration(durationString.get());
+            }
             recipeDescriptor.setDuration(duration);
+            recipeDescriptor.setDurationChanged(true);
         }
 
         Optional<String> portionString = argMultimap.getValue(PREFIX_PORTION);
         if (portionString.isPresent()) {
-            RecipePortion portion = parsePortion(portionString.get());
+            RecipePortion portion = null;
+            // handle the case where empty portion string is provided
+            // interpret this as: user wants to clear the portion field
+            if (!portionString.get().equals("")) {
+                portion = parsePortion(portionString.get());
+            }
             recipeDescriptor.setPortion(portion);
+            recipeDescriptor.setPortionChanged(true);
         }
 
         if (argMultimap.containsKey(PREFIX_TAG)) {

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -15,7 +16,9 @@ import seedu.recipe.model.recipe.Name;
 import seedu.recipe.model.recipe.RecipeDuration;
 import seedu.recipe.model.recipe.RecipePortion;
 import seedu.recipe.model.recipe.Step;
+import seedu.recipe.model.recipe.ingredient.Ingredient;
 import seedu.recipe.model.recipe.ingredient.IngredientBuilder;
+import seedu.recipe.model.recipe.ingredient.IngredientInformation;
 import seedu.recipe.model.tag.Tag;
 
 /**
@@ -90,11 +93,12 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code tag} is invalid.
      */
-    public static IngredientBuilder parseIngredient(String ingredient) throws ParseException {
+    public static HashMap<Ingredient, IngredientInformation> parseIngredient(String ingredient) throws ParseException {
         requireNonNull(ingredient);
         String trimmedIngredient = ingredient.trim();
         try {
-            return new IngredientBuilder(trimmedIngredient);
+            IngredientBuilder ingredientBuilder = new IngredientBuilder(trimmedIngredient);
+            return ingredientBuilder.build();
         } catch (IllegalArgumentException e) {
             throw new ParseException(IngredientBuilder.MESSAGE_CONSTRAINTS);
         }
@@ -106,13 +110,14 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code phone} is invalid.
      */
-    public static List<IngredientBuilder> parseIngredients(Collection<String> ingredients) throws ParseException {
+    public static HashMap<Ingredient, IngredientInformation> parseIngredients(
+        Collection<String> ingredients) throws ParseException {
         requireNonNull(ingredients);
-        List<IngredientBuilder> ingredientList = new ArrayList<>();
+        HashMap<Ingredient, IngredientInformation> ingredientMap = new HashMap<>();
         for (String ingredientName : ingredients) {
-            ingredientList.add(parseIngredient(ingredientName));
+            ingredientMap.putAll(parseIngredient(ingredientName));
         }
-        return ingredientList;
+        return ingredientMap;
     }
 
     /**

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -153,8 +153,12 @@ public class ParserUtil {
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
-        for (String tagName : tags) {
-            tagSet.add(parseTag(tagName));
+
+        // ensure tags are non-empty
+        if (tags.size() != 1 || !tags.contains("")) {
+            for (String tagName : tags) {
+                tagSet.add(parseTag(tagName));
+            }
         }
         return tagSet;
     }
@@ -185,8 +189,12 @@ public class ParserUtil {
     public static List<Step> parseSteps(Collection<String> steps) throws ParseException {
         requireNonNull(steps);
         List<Step> stepList = new ArrayList<>();
-        for (String stepDescription : steps) {
-            stepList.add(parseStep(stepDescription));
+
+        // ensure steps are non-empty
+        if (steps.size() != 1 || !steps.contains("")) {
+            for (String stepDescription : steps) {
+                stepList.add(parseStep(stepDescription));
+            }
         }
         return stepList;
     }
@@ -212,19 +220,19 @@ public class ParserUtil {
             recipeDescriptor.setPortion(portion);
         }
 
-        Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        if (!tags.isEmpty()) {
+        if (argMultimap.containsKey(PREFIX_TAG)) {
+            Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
             recipeDescriptor.setTags(tags);
         }
 
-        HashMap<Ingredient, IngredientInformation> ingredientTable = ParserUtil.parseIngredients(
-            argMultimap.getAllValues(PREFIX_INGREDIENT));
-        if (!ingredientTable.isEmpty()) {
+        if (argMultimap.containsKey(PREFIX_INGREDIENT)) {
+            HashMap<Ingredient, IngredientInformation> ingredientTable = ParserUtil.parseIngredients(
+                argMultimap.getAllValues(PREFIX_INGREDIENT));
             recipeDescriptor.setIngredients(ingredientTable);
         }
 
-        List<Step> steps = ParserUtil.parseSteps(argMultimap.getAllValues(PREFIX_STEP));
-        if (!steps.isEmpty()) {
+        if (argMultimap.containsKey(PREFIX_STEP)) {
+            List<Step> steps = ParserUtil.parseSteps(argMultimap.getAllValues(PREFIX_STEP));
             recipeDescriptor.setSteps(steps);
         }
 

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -13,12 +13,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.recipe.commons.core.index.Index;
 import seedu.recipe.commons.util.StringUtil;
 import seedu.recipe.logic.parser.exceptions.ParseException;
-import seedu.recipe.logic.parser.functional.TryUtil;
 import seedu.recipe.logic.util.RecipeDescriptor;
 import seedu.recipe.model.recipe.Name;
 import seedu.recipe.model.recipe.RecipeDuration;
@@ -190,17 +190,23 @@ public class ParserUtil {
     public static RecipeDescriptor parseToRecipeDescriptor(ArgumentMultimap argMultimap) throws ParseException {
         RecipeDescriptor recipeDescriptor = new RecipeDescriptor();
 
-        argMultimap.getValue(PREFIX_NAME)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseName, s))
-            .ifPresent(recipeDescriptor::setName);
+        Optional<String> nameString = argMultimap.getValue(PREFIX_NAME);
+        if (nameString.isPresent()) {
+            Name name = parseName(nameString.get());
+            recipeDescriptor.setName(name);
+        }
 
-        argMultimap.getValue(PREFIX_DURATION)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
-            .ifPresent(recipeDescriptor::setDuration);
+        Optional<String> durationString = argMultimap.getValue(PREFIX_DURATION);
+        if (durationString.isPresent()) {
+            RecipeDuration duration = parseDuration(durationString.get());
+            recipeDescriptor.setDuration(duration);
+        }
 
-        argMultimap.getValue(PREFIX_PORTION)
-            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
-            .ifPresent(recipeDescriptor::setPortion);
+        Optional<String> portionString = argMultimap.getValue(PREFIX_PORTION);
+        if (portionString.isPresent()) {
+            RecipePortion portion = parsePortion(portionString.get());
+            recipeDescriptor.setPortion(portion);
+        }
 
         Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         if (!tags.isEmpty()) {
@@ -220,5 +226,5 @@ public class ParserUtil {
 
         return recipeDescriptor;
     }
-    
+
 }

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -89,10 +89,12 @@ public class ParserUtil {
     public static RecipePortion parsePortion(String portion) throws ParseException {
         requireNonNull(portion);
         String trimmedPortion = portion.trim();
-        if (!RecipePortion.isValidRecipePortion(trimmedPortion)) {
-            throw new ParseException(RecipePortion.MESSAGE_CONSTRAINTS);
+
+        try {
+            return RecipePortion.of(trimmedPortion);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
         }
-        return RecipePortion.of(trimmedPortion);
     }
 
     /**

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -74,10 +74,12 @@ public class ParserUtil {
     public static RecipeDuration parseDuration(String duration) throws ParseException {
         requireNonNull(duration);
         String trimmedDuration = duration.trim();
-        if (!RecipeDuration.isValidRecipeDuration(trimmedDuration)) {
-            throw new ParseException(RecipeDuration.MESSAGE_CONSTRAINTS);
+
+        try {
+            return RecipeDuration.of(trimmedDuration);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
         }
-        return RecipeDuration.of(trimmedDuration);
     }
 
     /**

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -112,7 +112,7 @@ public class ParserUtil {
             IngredientBuilder ingredientBuilder = new IngredientBuilder(trimmedIngredient);
             return ingredientBuilder.build();
         } catch (IllegalArgumentException e) {
-            throw new ParseException(IngredientBuilder.MESSAGE_CONSTRAINTS);
+            throw new ParseException(e.getMessage());
         }
     }
 

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -220,7 +220,7 @@ public class ParserUtil {
             RecipeDuration duration = null;
             // handle the case where empty duration string is provided
             // interpret this as: user wants to clear the duration field
-            if (!durationString.get().equals("")) {
+            if (!durationString.get().trim().isEmpty()) {
                 duration = parseDuration(durationString.get());
             }
             recipeDescriptor.setDuration(duration);
@@ -232,7 +232,7 @@ public class ParserUtil {
             RecipePortion portion = null;
             // handle the case where empty portion string is provided
             // interpret this as: user wants to clear the portion field
-            if (!portionString.get().equals("")) {
+            if (!portionString.get().trim().isEmpty()) {
                 portion = parsePortion(portionString.get());
             }
             recipeDescriptor.setPortion(portion);

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -199,6 +199,13 @@ public class ParserUtil {
         return stepList;
     }
 
+    /**
+     * Creates a RecipeDescriptor from a multimap of recipe arguments.
+     *
+     * @param argMultimap Multimap of recipe arguments.
+     * @return RecipeDescriptor created from given argument multimap.
+     * @throws ParseException Thrown when any argument is unable to be properly parsed.
+     */
     public static RecipeDescriptor parseToRecipeDescriptor(ArgumentMultimap argMultimap) throws ParseException {
         RecipeDescriptor recipeDescriptor = new RecipeDescriptor();
 

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -1,6 +1,12 @@
 package seedu.recipe.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_DURATION;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_INGREDIENT;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_PORTION;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_STEP;
+import static seedu.recipe.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,6 +18,8 @@ import java.util.Set;
 import seedu.recipe.commons.core.index.Index;
 import seedu.recipe.commons.util.StringUtil;
 import seedu.recipe.logic.parser.exceptions.ParseException;
+import seedu.recipe.logic.parser.functional.TryUtil;
+import seedu.recipe.logic.util.RecipeDescriptor;
 import seedu.recipe.model.recipe.Name;
 import seedu.recipe.model.recipe.RecipeDuration;
 import seedu.recipe.model.recipe.RecipePortion;
@@ -178,4 +186,39 @@ public class ParserUtil {
         }
         return stepList;
     }
+
+    public static RecipeDescriptor parseToRecipeDescriptor(ArgumentMultimap argMultimap) throws ParseException {
+        RecipeDescriptor recipeDescriptor = new RecipeDescriptor();
+
+        argMultimap.getValue(PREFIX_NAME)
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseName, s))
+            .ifPresent(recipeDescriptor::setName);
+
+        argMultimap.getValue(PREFIX_DURATION)
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parseDuration, s))
+            .ifPresent(recipeDescriptor::setDuration);
+
+        argMultimap.getValue(PREFIX_PORTION)
+            .flatMap(s -> TryUtil.safeCompute(ParserUtil::parsePortion, s))
+            .ifPresent(recipeDescriptor::setPortion);
+
+        Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        if (!tags.isEmpty()) {
+            recipeDescriptor.setTags(tags);
+        }
+
+        HashMap<Ingredient, IngredientInformation> ingredientTable = ParserUtil.parseIngredients(
+            argMultimap.getAllValues(PREFIX_INGREDIENT));
+        if (!ingredientTable.isEmpty()) {
+            recipeDescriptor.setIngredients(ingredientTable);
+        }
+
+        List<Step> steps = ParserUtil.parseSteps(argMultimap.getAllValues(PREFIX_STEP));
+        if (!steps.isEmpty()) {
+            recipeDescriptor.setSteps(steps);
+        }
+
+        return recipeDescriptor;
+    }
+    
 }

--- a/src/main/java/seedu/recipe/logic/util/RecipeDescriptor.java
+++ b/src/main/java/seedu/recipe/logic/util/RecipeDescriptor.java
@@ -27,12 +27,16 @@ import seedu.recipe.model.tag.Tag;
 public class RecipeDescriptor {
     private Name name;
     private RecipeDuration duration;
+    private boolean durationChanged;
     private RecipePortion portion;
+    private boolean portionChanged;
     private Set<Tag> tags;
     private HashMap<Ingredient, IngredientInformation> ingredients;
     private List<Step> steps;
 
     public RecipeDescriptor() {
+        this.durationChanged = false;
+        this.portionChanged = false;
     }
 
     /**
@@ -46,6 +50,9 @@ public class RecipeDescriptor {
         setTags(toCopy.tags);
         setIngredients(toCopy.ingredients);
         setSteps(toCopy.steps);
+
+        this.durationChanged = toCopy.durationChanged;
+        this.portionChanged = toCopy.portionChanged;
     }
 
     /**
@@ -58,18 +65,20 @@ public class RecipeDescriptor {
         Name updatedName = getName().orElse(recipeToEdit.getName());
         Recipe newRecipe = new Recipe(updatedName);
 
-        RecipeDuration updatedDuration = getDuration().orElse(recipeToEdit.getDurationNullable());
+        RecipeDuration updatedDuration = getDuration().orElseGet(() -> durationChanged ? null :
+            recipeToEdit.getDurationNullable());
         newRecipe.setDuration(updatedDuration);
 
-        RecipePortion updatedPortion = getPortion().orElse(recipeToEdit.getPortionNullable());
+        RecipePortion updatedPortion = getPortion().orElseGet(
+            () -> portionChanged ? null : recipeToEdit.getPortionNullable());
         newRecipe.setPortion(updatedPortion);
 
         Tag[] updatedTags = getTags().orElse(recipeToEdit.getTags()).toArray(Tag[]::new);
         newRecipe.setTags(updatedTags);
 
         HashMap<Ingredient, IngredientInformation> updatedIngredients = getIngredients()
-                .map(HashMap::new)
-                .orElse(recipeToEdit.getIngredients());
+            .map(HashMap::new)
+            .orElse(recipeToEdit.getIngredients());
         newRecipe.setIngredients(updatedIngredients);
 
         Step[] updatedSteps = getSteps().orElse(recipeToEdit.getSteps()).toArray(Step[]::new);
@@ -90,7 +99,8 @@ public class RecipeDescriptor {
      * Returns true if at least one field is edited.
      */
     public boolean isAnyFieldEdited() {
-        return CollectionUtil.isAnyNonNull(name, duration, portion, tags, ingredients, steps);
+        return durationChanged || portionChanged || CollectionUtil.isAnyNonNull(name, duration, portion, tags,
+            ingredients, steps);
     }
 
     public Optional<Name> getName() {
@@ -106,7 +116,9 @@ public class RecipeDescriptor {
     }
 
     public void setDuration(RecipeDuration duration) {
-        this.duration = duration;
+        if (duration != null) {
+            this.duration = duration;
+        }
     }
 
     public Optional<RecipePortion> getPortion() {
@@ -156,6 +168,14 @@ public class RecipeDescriptor {
         this.steps = (steps != null) ? new ArrayList<>(steps) : null;
     }
 
+    public void setDurationChanged(boolean durationChanged) {
+        this.durationChanged = durationChanged;
+    }
+
+    public void setPortionChanged(boolean portionChanged) {
+        this.portionChanged = portionChanged;
+    }
+
     @Override
     public boolean equals(Object other) {
         // short circuit if same object
@@ -172,10 +192,10 @@ public class RecipeDescriptor {
         RecipeDescriptor e = (RecipeDescriptor) other;
 
         return getName().equals(e.getName())
-                && getDuration().equals(e.getDuration())
-                && getPortion().equals(e.getPortion())
-                && getTags().equals(e.getTags())
-                && getIngredients().equals(e.getIngredients())
-                && getSteps().equals(e.getSteps());
+            && getDuration().equals(e.getDuration())
+            && getPortion().equals(e.getPortion())
+            && getTags().equals(e.getTags())
+            && getIngredients().equals(e.getIngredients())
+            && getSteps().equals(e.getSteps());
     }
 }

--- a/src/main/java/seedu/recipe/logic/util/RecipeDescriptor.java
+++ b/src/main/java/seedu/recipe/logic/util/RecipeDescriptor.java
@@ -34,13 +34,16 @@ public class RecipeDescriptor {
     private HashMap<Ingredient, IngredientInformation> ingredients;
     private List<Step> steps;
 
+    /**
+     * Instantiates a new RecipeDescriptor object.
+     */
     public RecipeDescriptor() {
         this.durationChanged = false;
         this.portionChanged = false;
     }
 
     /**
-     * Copy constructor.
+     * Creates a copy of a given RecipeDescriptor object.
      * A defensive copy of {@code tags} is used internally.
      */
     public RecipeDescriptor(RecipeDescriptor toCopy) {
@@ -65,12 +68,12 @@ public class RecipeDescriptor {
         Name updatedName = getName().orElse(recipeToEdit.getName());
         Recipe newRecipe = new Recipe(updatedName);
 
-        RecipeDuration updatedDuration = getDuration().orElseGet(() -> durationChanged ? null :
-            recipeToEdit.getDurationNullable());
+        RecipeDuration updatedDuration = getDuration().orElseGet(() -> durationChanged ? null
+            : recipeToEdit.getDurationNullable());
         newRecipe.setDuration(updatedDuration);
 
-        RecipePortion updatedPortion = getPortion().orElseGet(
-            () -> portionChanged ? null : recipeToEdit.getPortionNullable());
+        RecipePortion updatedPortion = getPortion().orElseGet((
+        ) -> portionChanged ? null : recipeToEdit.getPortionNullable()); // checkstyle'd
         newRecipe.setPortion(updatedPortion);
 
         Tag[] updatedTags = getTags().orElse(recipeToEdit.getTags()).toArray(Tag[]::new);

--- a/src/main/java/seedu/recipe/model/recipe/Name.java
+++ b/src/main/java/seedu/recipe/model/recipe/Name.java
@@ -9,14 +9,12 @@ import static seedu.recipe.commons.util.AppUtil.checkArgument;
  */
 public class Name {
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+        "Names should only contain alphanumeric characters, spaces, and the following special characters: \' \" -\n"
+            + "Names cannot be blank.";
 
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX =
-            "^(([1-9][0-9]?(\\-)?\\s*)?[A-Za-z]+)(\\-[A-Za-z]+)?(\\s+[A-Za-z0-9\\-]*)*$";
+    // syntax: any combination of alphanumeric characters and
+    // the following special characters: " ' -
+    public static final String VALIDATION_REGEX = "[A-Za-z0-9\\-'\"](?: *[A-Za-z0-9\\-'\"]+)*";
 
     public final String recipeName;
 
@@ -47,8 +45,8 @@ public class Name {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof Name // instanceof handles nulls
-                && recipeName.equals(((Name) other).recipeName)); // state check
+            || (other instanceof Name // instanceof handles nulls
+            && recipeName.equals(((Name) other).recipeName)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/recipe/model/recipe/Recipe.java
+++ b/src/main/java/seedu/recipe/model/recipe/Recipe.java
@@ -54,20 +54,20 @@ public class Recipe {
         return ingredientTable;
     }
 
-    public Set<Ingredient> getIngredientList() {
-        return ingredientTable.keySet();
-    }
-
     public void setIngredients(IngredientBuilder... ingredients) {
-        for (IngredientBuilder ingredientBuilder: ingredients) {
+        for (IngredientBuilder ingredientBuilder : ingredients) {
             ingredientTable.putAll(
                 ingredientBuilder.build()
-            );
+                                  );
         }
     }
 
     public void setIngredients(Map<? extends Ingredient, ? extends IngredientInformation> ingredientMap) {
         this.ingredientTable.putAll(ingredientMap);
+    }
+
+    public Set<Ingredient> getIngredientList() {
+        return ingredientTable.keySet();
     }
 
     public RecipePortion getPortion() {
@@ -130,7 +130,7 @@ public class Recipe {
         }
 
         return otherRecipe != null
-                && otherRecipe.getName().equals(getName());
+            && otherRecipe.getName().equals(getName());
     }
 
     /**
@@ -149,11 +149,11 @@ public class Recipe {
 
         Recipe otherRecipe = (Recipe) other;
         return otherRecipe.getName().equals(getName())
-                && otherRecipe.getPortion().equals(getPortion())
-                && otherRecipe.getDuration().equals(getDuration())
-                && otherRecipe.getTags().equals(getTags())
-                && otherRecipe.getIngredients().equals(getIngredients())
-                && otherRecipe.getSteps().equals(getSteps());
+            && otherRecipe.portion.equals(portion)
+            && otherRecipe.duration.equals(duration)
+            && otherRecipe.getTags().equals(getTags())
+            && otherRecipe.getIngredients().equals(getIngredients())
+            && otherRecipe.getSteps().equals(getSteps());
     }
 
     @Override

--- a/src/main/java/seedu/recipe/model/recipe/Recipe.java
+++ b/src/main/java/seedu/recipe/model/recipe/Recipe.java
@@ -57,8 +57,7 @@ public class Recipe {
     public void setIngredients(IngredientBuilder... ingredients) {
         for (IngredientBuilder ingredientBuilder : ingredients) {
             ingredientTable.putAll(
-                ingredientBuilder.build()
-                                  );
+                ingredientBuilder.build());
         }
     }
 

--- a/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import seedu.recipe.model.recipe.exceptions.RecipeDurationInvalidDurationException;
 import seedu.recipe.model.recipe.unit.TimeUnit;
 
 /**
@@ -27,6 +28,9 @@ public class RecipeDuration {
      * @param timeUnit The time unit instance
      */
     public RecipeDuration(double time, TimeUnit timeUnit) {
+        if (time < 0) {
+            throw new RecipeDurationInvalidDurationException(String.valueOf(time));
+        }
         this.time = time;
         this.timeUnit = timeUnit;
     }

--- a/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
@@ -1,11 +1,9 @@
 package seedu.recipe.model.recipe;
 
-import static seedu.recipe.commons.util.AppUtil.checkArgument;
-
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import seedu.recipe.model.recipe.exceptions.RecipeDurationInvalidArgumentLengthException;
-import seedu.recipe.model.recipe.exceptions.RecipeDurationInvalidDurationException;
 import seedu.recipe.model.recipe.unit.TimeUnit;
 
 /**
@@ -13,10 +11,12 @@ import seedu.recipe.model.recipe.unit.TimeUnit;
  */
 public class RecipeDuration {
     public static final String MESSAGE_CONSTRAINTS =
-            "A Recipe Duration should consist of a numeric/decimal section and an alphanumeric time unit";
+        "A Recipe Duration should consist of a numeric/decimal section and an alphabetic time unit";
     private static final String VALIDATION_REGEX =
-            "^(([2-9]\\d{0,2}|1\\d{1,2})(\\.\\d{1,3})?|[01]\\.\\d{0,2}[1-9])\\s+((hour|minute|second|day)s|min|h)$|"
-                    + "^(1|1.0)\\s+(hour|minute|day|second|min|h)$";
+        "^(([2-9]\\d{0,2}|1\\d{1,2})(\\.\\d{1,3})?|[01]\\.\\d{0,2}[1-9])\\s+((hour|minute|second|day)s|min|h)$|"
+            + "^(1|1.0)\\s+(hour|minute|day|second|min|h)$";
+
+    private static final Pattern NEW_REGEX = Pattern.compile("((\\d+)(?:([.\\/])(\\d+))?)\\s+([A-Za-z ]+)");
 
     private final double time;
     private final TimeUnit timeUnit;
@@ -28,38 +28,43 @@ public class RecipeDuration {
      * @param timeUnit The time unit instance
      */
     public RecipeDuration(double time, TimeUnit timeUnit) {
-        checkArgument(isValidRecipeDuration(String.format("%s %s", time, timeUnit.toString())), MESSAGE_CONSTRAINTS);
         this.time = time;
         this.timeUnit = timeUnit;
     }
 
     /**
-     * Returns whether a given String is a valid RecipeDuration.
-     *
-     * @param test the string to test.
-     * @return true if the String is a valid RecipeDuration in accordance to the regex, false otherwise.
-     */
-    public static boolean isValidRecipeDuration(String test) {
-        return test.matches(VALIDATION_REGEX);
-    }
-
-    /**
      * Generates an instance of a RecipeDuration Object, provided the parameter string is formatted correctly.
      *
-     * @param duration The parameter string to input the time and unit into this factory.
+     * @param candidate The parameter string to input the time and unit into this factory.
      * @return The generated RecipeDuration instance, if the parameter is valid.
      */
-    public static RecipeDuration of(String duration) {
-        String[] tokens = duration.split("\\s+");
-        if (tokens.length != 2) {
-            throw new RecipeDurationInvalidArgumentLengthException();
+    public static RecipeDuration of(String candidate) {
+        Matcher matcher = NEW_REGEX.matcher(candidate);
+
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
         }
-        if (!isValidRecipeDuration(duration)) {
-            throw new RecipeDurationInvalidDurationException(duration);
+
+        // 5 capture groups in the regex, so if the candidate string matches,
+        // there should be 5 groups captured!
+        assert matcher.groupCount() == 5;
+
+        // parse time amount
+        double time;
+        if (matcher.group(3) != null && matcher.group(3).equals("/")) {
+            // parse fractions
+            double group1 = Double.parseDouble((matcher.group(2)));
+            double group2 = Double.parseDouble((matcher.group(4)));
+            time = group1 / group2;
+        } else {
+            // parse integers or decimals
+            time = Double.parseDouble(matcher.group(1));
         }
-        //No format exception will occur, thanks to regex
-        double timeAmount = Double.parseDouble(tokens[0]);
-        return new RecipeDuration(timeAmount, new TimeUnit(tokens[1]));
+
+        // parse time unit
+        String unitString = matcher.group(5);
+
+        return new RecipeDuration(time, new TimeUnit(unitString));
     }
 
     @Override
@@ -83,8 +88,8 @@ public class RecipeDuration {
     @Override
     public boolean equals(Object o) {
         return o == this
-                || o instanceof RecipeDuration
-                && ((RecipeDuration) o).time == this.time
-                && ((RecipeDuration) o).timeUnit.equals(this.timeUnit);
+            || o instanceof RecipeDuration
+            && ((RecipeDuration) o).time == this.time
+            && ((RecipeDuration) o).timeUnit.equals(this.timeUnit);
     }
 }

--- a/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
@@ -12,11 +12,9 @@ import seedu.recipe.model.recipe.unit.TimeUnit;
 public class RecipeDuration {
     public static final String MESSAGE_CONSTRAINTS =
         "A Recipe Duration should consist of a numeric/decimal section and an alphabetic time unit";
-    private static final String VALIDATION_REGEX =
-        "^(([2-9]\\d{0,2}|1\\d{1,2})(\\.\\d{1,3})?|[01]\\.\\d{0,2}[1-9])\\s+((hour|minute|second|day)s|min|h)$|"
-            + "^(1|1.0)\\s+(hour|minute|day|second|min|h)$";
 
-    private static final Pattern NEW_REGEX = Pattern.compile("((\\d+)(?:([.\\/])(\\d+))?)\\s+([A-Za-z ]+)");
+    // format: {number} {unit} OR {number}{. or /}{number} {unit}
+    private static final Pattern VALIDATION_REGEX = Pattern.compile("((\\d+)(?:([.\\/])(\\d+))?)\\s+([A-Za-z ]+)");
 
     private final double time;
     private final TimeUnit timeUnit;
@@ -39,7 +37,7 @@ public class RecipeDuration {
      * @return The generated RecipeDuration instance, if the parameter is valid.
      */
     public static RecipeDuration of(String candidate) {
-        Matcher matcher = NEW_REGEX.matcher(candidate);
+        Matcher matcher = VALIDATION_REGEX.matcher(candidate);
 
         if (!matcher.matches()) {
             throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipeDuration.java
@@ -11,7 +11,8 @@ import seedu.recipe.model.recipe.unit.TimeUnit;
  */
 public class RecipeDuration {
     public static final String MESSAGE_CONSTRAINTS =
-        "A Recipe Duration should consist of a numeric/decimal section and an alphabetic time unit";
+        "A Recipe's duration should consist of an integer/fraction/decimal section and an alphabetic time unit "
+            + "(spaces allowed)";
 
     // format: {number} {unit} OR {number}{. or /}{number} {unit}
     private static final Pattern VALIDATION_REGEX = Pattern.compile("((\\d+)(?:([.\\/])(\\d+))?)\\s+([A-Za-z ]+)");

--- a/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
@@ -66,10 +66,10 @@ public class RecipePortion {
         String upperString = matcher.group(2);
         String unitString = matcher.group(3);
 
-        Integer lower = Integer.parseInt(lowerString);
-        Integer upper = upperString == null ? null : Integer.parseInt(upperString);
+        int lower = Integer.parseInt(lowerString);
+        int upper = upperString == null ? 0 : Integer.parseInt(upperString);
 
-        if (upper < lower) {
+        if (upperString != null && upper < lower) {
             throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
         }
 

--- a/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
@@ -9,7 +9,6 @@ import seedu.recipe.model.recipe.unit.PortionUnit;
 
 /**
  * Represents a Recipe's portion in the RecipeBook.
- * Guarantees: immutable; is valid as declared in {@link #isValidRecipePortion(String)}
  */
 public class RecipePortion {
     public static final String MESSAGE_CONSTRAINTS =

--- a/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import seedu.recipe.model.recipe.exceptions.RecipePortionInvalidArgumentException;
 import seedu.recipe.model.recipe.unit.PortionUnit;
 
 /**
@@ -31,6 +32,12 @@ public class RecipePortion {
      * @param portionUnit The portion unit instance
      */
     public RecipePortion(int lowerRange, int upperRange, PortionUnit portionUnit) {
+        if (lowerRange < 0) {
+            throw new RecipePortionInvalidArgumentException(String.valueOf(upperRange));
+        }
+        if (upperRange != 0 && upperRange < lowerRange) {
+            throw new RecipePortionInvalidArgumentException(String.valueOf(upperRange));
+        }
         this.lowerRange = lowerRange;
         this.upperRange = upperRange;
         this.portionUnit = portionUnit;
@@ -68,10 +75,6 @@ public class RecipePortion {
 
         int lower = Integer.parseInt(lowerString);
         int upper = upperString == null ? 0 : Integer.parseInt(upperString);
-
-        if (upperString != null && upper < lower) {
-            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
-        }
 
         return new RecipePortion(lower, upper, new PortionUnit(unitString));
     }

--- a/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
@@ -12,10 +12,12 @@ import seedu.recipe.model.recipe.unit.PortionUnit;
  */
 public class RecipePortion {
     public static final String MESSAGE_CONSTRAINTS =
-        "Recipe Portion's upper and lower ranges should only contain numbers, and its unit should only contain "
-            + "alphanumeric characters, and it should not be blank";
+        "A Recipe portion's ranges must be numeric.\n"
+            + "If a lower and upper range is provided, they must be separated by \"-\" or \"to\".\n"
+            + "Its unit should only contain alphabetic characters and spaces, and it should not be blank";
     // format: {number} {unit} OR {number} {- or to} {number} {unit}
-    public static final Pattern VALIDATION_REGEX = Pattern.compile("(\\d+)(?:\\s*(?:-|to)\\s*(\\d+))?\\s*([A-Za-z ]+)");
+    public static final Pattern VALIDATION_REGEX =
+        Pattern.compile("(\\d+)(?:\\s*(?:-|to)\\s*(\\d+))?\\s*([A-Za-z ]+)");
 
     private final int lowerRange;
     private final int upperRange;

--- a/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
+++ b/src/main/java/seedu/recipe/model/recipe/RecipePortion.java
@@ -45,14 +45,6 @@ public class RecipePortion {
 
     /**
      * Checks if the provided String is formatted properly and can be split into the appropriate tokens to
-     * generate a RecipePortion instance.
-     *
-     * @param test The string to test.
-     * @return The boolean indicating if it is valid.
-     */
-
-    /**
-     * Checks if the provided String is formatted properly and can be split into the appropriate tokens to
      * generate a RecipePortion instance. Returns a RecipePortion instance if the candidate is valid.
      *
      * @param candidate The string to construct around.

--- a/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeDurationInvalidArgumentLengthException.java
+++ b/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeDurationInvalidArgumentLengthException.java
@@ -4,13 +4,13 @@ package seedu.recipe.model.recipe.exceptions;
  * Represents the exception that arises when a parameter string of invalid length is passed into the
  * factory method {@code ::of} of the RecipeDuration class.
  */
-public class RecipeDurationInvalidArgumentLengthException extends RuntimeException {
+public class RecipeDurationInvalidArgumentLengthException extends IllegalArgumentException {
     /**
      * Constructs and returns an instance of this exception with the formatted message.
      */
     public RecipeDurationInvalidArgumentLengthException() {
         super("An argument list of invalid length was passed for a Recipe Duration."
-                      + "\nEnsure it is of the following format: '{number OR decimal} {duration}; "
-                      + "\nExample: `1 minute`, `1.5 hours`");
+            + "\nEnsure it is of the following format: '{number OR decimal} {duration}; "
+            + "\nExample: `1 minute`, `1.5 hours`");
     }
 }

--- a/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeDurationInvalidDurationException.java
+++ b/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeDurationInvalidDurationException.java
@@ -4,12 +4,12 @@ package seedu.recipe.model.recipe.exceptions;
  * Represents the exception that arises when a parameter string representing an invalid duration is passed into the
  * factory method {@code ::of} of the RecipeDuration class.
  */
-public class RecipeDurationInvalidDurationException extends RuntimeException {
+public class RecipeDurationInvalidDurationException extends IllegalArgumentException {
     /**
      * Constructs and returns an instance of this exception with the formatted message.
      */
     public RecipeDurationInvalidDurationException(String durationCandidate) {
         super(String.format("An invalid amount of time was provided for the Recipe Duration: `%s`", durationCandidate)
-                      + "\nEnsure it is a valid number/decimal");
+            + "\nEnsure it is a valid number/decimal");
     }
 }

--- a/src/main/java/seedu/recipe/model/recipe/exceptions/RecipePortionInvalidArgumentException.java
+++ b/src/main/java/seedu/recipe/model/recipe/exceptions/RecipePortionInvalidArgumentException.java
@@ -4,7 +4,7 @@ package seedu.recipe.model.recipe.exceptions;
  * Represents the exception that arises when a parameter string representing an invalid portion is passed into the
  * factory method {@code ::of} of the RecipePortion class.
  */
-public class RecipePortionInvalidArgumentException extends RuntimeException {
+public class RecipePortionInvalidArgumentException extends IllegalArgumentException {
     public RecipePortionInvalidArgumentException(String s) {
         super(String.format("An invalid argument `%s` was provided for the Recipe portion.", s));
     }

--- a/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeQuantityInvalidArgumentException.java
+++ b/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeQuantityInvalidArgumentException.java
@@ -16,8 +16,6 @@ public class RecipeQuantityInvalidArgumentException extends IllegalArgumentExcep
         super(
             String.format(
                 "An invalid quantity expression \"%s\" was passed for this ingredient.\n%s",
-                s, IngredientQuantity.MESSAGE_CONSTRAINTS
-                         )
-             );
+                s, IngredientQuantity.MESSAGE_CONSTRAINTS));
     }
 }

--- a/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeQuantityInvalidArgumentException.java
+++ b/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeQuantityInvalidArgumentException.java
@@ -15,7 +15,7 @@ public class RecipeQuantityInvalidArgumentException extends IllegalArgumentExcep
     public RecipeQuantityInvalidArgumentException(String s) {
         super(
             String.format(
-                "An invalid quantity expression %s was passed for this ingredient. %s",
+                "An invalid quantity expression \"%s\" was passed for this ingredient.\n%s",
                 s, IngredientQuantity.MESSAGE_CONSTRAINTS
                          )
              );

--- a/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeQuantityInvalidArgumentException.java
+++ b/src/main/java/seedu/recipe/model/recipe/exceptions/RecipeQuantityInvalidArgumentException.java
@@ -6,9 +6,10 @@ import seedu.recipe.model.recipe.ingredient.IngredientQuantity;
  * Represents the exception that arises when a parameter string not containing a portion is passed into the
  * factory method {@code ::of} of the IngredientQuantity class.
  */
-public class RecipeQuantityInvalidArgumentException extends RuntimeException {
+public class RecipeQuantityInvalidArgumentException extends IllegalArgumentException {
     /**
      * Generates and returns an instance of this Exception, with the provided argument string.
+     *
      * @param s The invalid argument that was entered into the IngredientQuantity {@code ::of} method.
      */
     public RecipeQuantityInvalidArgumentException(String s) {
@@ -16,7 +17,7 @@ public class RecipeQuantityInvalidArgumentException extends RuntimeException {
             String.format(
                 "An invalid quantity expression %s was passed for this ingredient. %s",
                 s, IngredientQuantity.MESSAGE_CONSTRAINTS
-            )
-        );
+                         )
+             );
     }
 }

--- a/src/main/java/seedu/recipe/model/recipe/ingredient/Ingredient.java
+++ b/src/main/java/seedu/recipe/model/recipe/ingredient/Ingredient.java
@@ -8,8 +8,9 @@ import java.util.Objects;
  * Represents an ingredient that is used in a {@code Recipe}.
  */
 public class Ingredient implements Comparable<Ingredient> {
-    public static final String MESSAGE_CONSTRAINTS = "An ingredient should be made up of one or more groups of "
-        + "whitespace separated alphabetic characters. These characters may also be separated by "
+    public static final String MESSAGE_CONSTRAINTS = "Invalid ingredient name: %s\n"
+        + "An ingredient should be made up of one or more groups of "
+        + "whitespace separated alphabetic characters. \nThese characters may also be separated by "
         + "singular hyphens, such as 'self-raising flour'.";
     private static final String WORD_GROUP = "[A-Za-z]+(\\-[A-Za-z]+)?";
     public static final String VALIDATION_REGEX = String.format("^%s(\\s+%s)*$", WORD_GROUP, WORD_GROUP);
@@ -31,7 +32,8 @@ public class Ingredient implements Comparable<Ingredient> {
      */
     public static Ingredient of(String s) {
         assert s != null;
-        checkArgument(isValidIngredientName(s), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidIngredientName(s),
+            String.format(MESSAGE_CONSTRAINTS, s));
         return new Ingredient(s);
     }
 
@@ -88,7 +90,7 @@ public class Ingredient implements Comparable<Ingredient> {
      */
     public void setCommonName(String s) {
         assert s != null;
-        checkArgument(isValidIngredientName(s), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidIngredientName(s), String.format(MESSAGE_CONSTRAINTS, s));
         this.commonName = s;
     }
 

--- a/src/main/java/seedu/recipe/model/recipe/ingredient/IngredientBuilder.java
+++ b/src/main/java/seedu/recipe/model/recipe/ingredient/IngredientBuilder.java
@@ -78,18 +78,16 @@ public class IngredientBuilder {
         }
         //Remarks
         information.getRemarks().forEach(remark ->
-                commandString.append(REMARK_PREFIX.getPrefix())
-                    .append(" ")
-                    .append(remark)
-                    .append(" ")
-                                        );
+            commandString.append(REMARK_PREFIX.getPrefix())
+                .append(" ")
+                .append(remark)
+                .append(" "));
         //Substitutions
         information.getSubstitutions().forEach(ingredient ->
-                commandString.append(SUBSTITUTION_PREFIX.getPrefix())
-                    .append(" ")
-                    .append(ingredient.getName())
-                    .append(" ")
-                                              );
+            commandString.append(SUBSTITUTION_PREFIX.getPrefix())
+                .append(" ")
+                .append(ingredient.getName())
+                .append(" "));
 
         HashMap<Prefix, List<String>> tokens = IngredientParser.parse(commandString.toString());
         checkArgument(tokens.containsKey(NAME_PREFIX), MESSAGE_CONSTRAINTS);
@@ -157,16 +155,14 @@ public class IngredientBuilder {
             List<String> remarkList = arguments.get(REMARK_PREFIX);
             remarks.addAll(remarkList.stream()
                 .filter(s -> s.matches("^[A-Za-z]+(\\s+[A-Za-z]+)*"))
-                .collect(Collectors.toList()
-                        ));
+                .collect(Collectors.toList()));
         }
         if (arguments.containsKey(SUBSTITUTION_PREFIX)) { //Substitutions
             //Invalid substitutions will indicate to the system via errors thrown by Ingredient.
             substitutes.addAll(arguments.get(SUBSTITUTION_PREFIX)
-                    .stream()
-                    .map(Ingredient::of)
-                    .collect(Collectors.toList())
-                              );
+                .stream()
+                .map(Ingredient::of)
+                .collect(Collectors.toList()));
         }
         return new IngredientInformation(
             quantity,

--- a/src/main/java/seedu/recipe/model/recipe/ingredient/IngredientBuilder.java
+++ b/src/main/java/seedu/recipe/model/recipe/ingredient/IngredientBuilder.java
@@ -24,10 +24,10 @@ import seedu.recipe.logic.parser.Prefix;
  */
 public class IngredientBuilder {
     public static final String MESSAGE_CONSTRAINTS =
-            "Ingredients should follow this format: \n"
-            + "`[-a AMOUNT] [-e ESTIMATED AMOUNT] -n NAME `"
-            + "`[-cn COMMON NAME] [-r REMARKS]... [-s SUBSTITUTION]...\n"
-            + "i.e. `-a 1 oz. -n butter -r cubed -s margarine`";
+        "Ingredients should follow this format: \n"
+            + "[-a AMOUNT] [-e ESTIMATED AMOUNT] -n NAME "
+            + "[-cn COMMON NAME] [-r REMARKS]... [-s SUBSTITUTION]...\n"
+            + "i.e. -a 1 oz. -n butter -r cubed -s margarine";
 
     private final String commandString;
 
@@ -49,25 +49,26 @@ public class IngredientBuilder {
     /**
      * Constructs an {@code IngredientBuilder} instance, from a Recipe instance's Ingredient Key-Value pair.
      * This is used for UI conversion for the Edit form functionality.
+     *
      * @param mainIngredient The Recipe instance's valid ingredient key.
-     * @param information The Recipe instance's valid IngredientInformation value assigned to the Ingredient key.
+     * @param information    The Recipe instance's valid IngredientInformation value assigned to the Ingredient key.
      */
     public IngredientBuilder(Ingredient mainIngredient, IngredientInformation information) {
         StringBuilder commandString = new StringBuilder();
 
         //Quantity
         information.getQuantity()
-                .map(v -> AMOUNT_PREFIX.getPrefix() + " " + v + " ")
-                .ifPresent(commandString::append);
+            .map(v -> AMOUNT_PREFIX.getPrefix() + " " + v + " ")
+            .ifPresent(commandString::append);
         //Estimated Amount
         information.getEstimatedQuantity()
-                .map(v -> ESTIMATE_PREFIX.getPrefix() + " " + v + " ")
-                .ifPresent(commandString::append);
+            .map(v -> ESTIMATE_PREFIX.getPrefix() + " " + v + " ")
+            .ifPresent(commandString::append);
         //Name
         commandString.append(NAME_PREFIX)
-                .append(" ")
-                .append(mainIngredient.getName())
-                .append(" ");
+            .append(" ")
+            .append(mainIngredient.getName())
+            .append(" ");
         //Common Name
         if (!mainIngredient.getCommonName().isEmpty()) {
             commandString.append(COMMON_NAME_PREFIX.getPrefix())
@@ -77,18 +78,18 @@ public class IngredientBuilder {
         }
         //Remarks
         information.getRemarks().forEach(remark ->
-            commandString.append(REMARK_PREFIX.getPrefix())
-                .append(" ")
-                .append(remark)
-                .append(" ")
-        );
+                commandString.append(REMARK_PREFIX.getPrefix())
+                    .append(" ")
+                    .append(remark)
+                    .append(" ")
+                                        );
         //Substitutions
         information.getSubstitutions().forEach(ingredient ->
                 commandString.append(SUBSTITUTION_PREFIX.getPrefix())
-                .append(" ")
-                .append(ingredient.getName())
-                .append(" ")
-        );
+                    .append(" ")
+                    .append(ingredient.getName())
+                    .append(" ")
+                                              );
 
         HashMap<Prefix, List<String>> tokens = IngredientParser.parse(commandString.toString());
         checkArgument(tokens.containsKey(NAME_PREFIX), MESSAGE_CONSTRAINTS);
@@ -108,6 +109,7 @@ public class IngredientBuilder {
     /**
      * Generates and returns a Key-Value pair for the enclosing {@code Recipe}
      * instance to store.
+     *
      * @return The {@code HashMap} instance containing the key-value pair.
      */
     public HashMap<Ingredient, IngredientInformation> build() {
@@ -119,6 +121,7 @@ public class IngredientBuilder {
     /**
      * Parses the prefix table for the fields pertaining to an Ingredient instance, creates, and returns a new
      * Ingredient instance around those fields.
+     *
      * @return The new Ingredient instance.
      */
     private Ingredient createMainIngredient() {
@@ -133,6 +136,7 @@ public class IngredientBuilder {
     /**
      * Parses the prefix table for the fields pertaining to an IngredientInformation instance, creates,
      * and returns an IngredientInformation instance around those fields.
+     *
      * @return The IngredientInformation instance.
      */
     private IngredientInformation createInformation() {
@@ -154,15 +158,15 @@ public class IngredientBuilder {
             remarks.addAll(remarkList.stream()
                 .filter(s -> s.matches("^[A-Za-z]+(\\s+[A-Za-z]+)*"))
                 .collect(Collectors.toList()
-                ));
+                        ));
         }
         if (arguments.containsKey(SUBSTITUTION_PREFIX)) { //Substitutions
             //Invalid substitutions will indicate to the system via errors thrown by Ingredient.
             substitutes.addAll(arguments.get(SUBSTITUTION_PREFIX)
-                .stream()
-                .map(Ingredient::of)
-                .collect(Collectors.toList())
-            );
+                    .stream()
+                    .map(Ingredient::of)
+                    .collect(Collectors.toList())
+                              );
         }
         return new IngredientInformation(
             quantity,
@@ -180,9 +184,9 @@ public class IngredientBuilder {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof IngredientBuilder // instanceof handles nulls
-                && commandString.equals(((IngredientBuilder) other).commandString)) // state check
-                && arguments.equals(((IngredientBuilder) other).arguments);
+            || (other instanceof IngredientBuilder // instanceof handles nulls
+            && commandString.equals(((IngredientBuilder) other).commandString)) // state check
+            && arguments.equals(((IngredientBuilder) other).arguments);
     }
 
     @Override

--- a/src/main/java/seedu/recipe/model/recipe/ingredient/IngredientQuantity.java
+++ b/src/main/java/seedu/recipe/model/recipe/ingredient/IngredientQuantity.java
@@ -7,11 +7,11 @@ import seedu.recipe.model.recipe.exceptions.RecipeQuantityInvalidArgumentExcepti
  */
 public class IngredientQuantity {
     public static final String MESSAGE_CONSTRAINTS =
-            "The quantity field for a Recipe Ingredient should consist of this format: "
+        "The quantity field for a Recipe Ingredient should consist of this format: "
             + "`{amount} {unit}`, where the amount can either be a non-zero decimal, i.e. `A/a` or `One/one`, "
-            + "and the unit should comprise of alphabetic characters, with minimal use of "
+            + "\nand the unit should comprise of alphabetic characters, with minimal use of "
             + "trailing periods ('.') and hyphens."
-            + "i.e. `1 gram`, `1.5 L`, `A pinch of`, `One oz.`";
+            + "\ni.e. `1 gram`, `1.5 L`, `A pinch of`, `One oz.`";
 
     //"A", "a", "One", "one"
     private static final String ALPHA_AMOUNT_REGEX = "[aA]|[Oo]ne";
@@ -21,7 +21,7 @@ public class IngredientQuantity {
 
     //The above two, or a non-zero digit/decimal/fraction
     private static final String AMOUNT_REGEX = String.format(
-            "([1-9][0-9]*|[0-9]+[\\./][0-9]*[1-9]|%s|%s)", ALPHA_AMOUNT_REGEX, RANGE_REGEX);
+        "([1-9][0-9]*|[0-9]+[\\./][0-9]*[1-9]|%s|%s)", ALPHA_AMOUNT_REGEX, RANGE_REGEX);
 
     //The above patterns, followed by at least one group of whitespace separated alphabet groups
     private static final String VALIDATION_REGEX = String.format("^%s(\\s+[A-Za-z]+\\.?)*", AMOUNT_REGEX);
@@ -31,6 +31,7 @@ public class IngredientQuantity {
     /**
      * Instantiates an IngredientQuantity instance around
      * a String representing a valid Ingredient Quantity amount.
+     *
      * @param amount The String amount to be stored.
      */
     private IngredientQuantity(String amount) {
@@ -39,6 +40,7 @@ public class IngredientQuantity {
 
     /**
      * Tests and validates sample String patterns to check if they form valid Recipe Ingredient Quantities.
+     *
      * @param candidate The sample pattern String to test.
      * @return True if it is valid, False otherwise.
      */
@@ -67,6 +69,7 @@ public class IngredientQuantity {
      * Validates the String parameter candidate passed in as an argument,
      * and generates and returns a IngredientQuantity instance, if
      * it is valid.
+     *
      * @param candidate The string parameter to be checked.
      * @return The quantity instance.
      */

--- a/src/test/data/JsonRecipeBookStorageTest/invalidRecipeRecipeBook.json
+++ b/src/test/data/JsonRecipeBookStorageTest/invalidRecipeRecipeBook.json
@@ -1,7 +1,7 @@
 {
   "recipes": [
     {
-      "name": "7896"
+      "name": "Bobby`s 39th Birthday Cake"
     }
   ]
 }

--- a/src/test/data/JsonSerializableRecipeBookTest/invalidRecipeRecipeBook.json
+++ b/src/test/data/JsonSerializableRecipeBookTest/invalidRecipeRecipeBook.json
@@ -1,7 +1,7 @@
 {
   "recipes": [
     {
-      "name": "1234"
+      "name": "Bobby`s 39th Birthday Cake"
     }
   ]
 }

--- a/src/test/data/JsonSerializableRecipeBookTest/typicalRecipeRecipeBook.json
+++ b/src/test/data/JsonSerializableRecipeBookTest/typicalRecipeRecipeBook.json
@@ -1,324 +1,496 @@
 {
   "_comment": "RecipeBook save file which contains the same Recipe values as in TypicalRecipes#getTypicalRecipeBook()",
-  "recipes" : [ {
-    "name" : "Cacio e Pepe",
-    "portion" : {
-      "lowerRange" : 1,
-      "upperRange" : 2,
-      "portionUnit" : "servings"
+  "recipes": [
+    {
+      "name": "Cacio e Pepe",
+      "portion": {
+        "lowerRange": 1,
+        "upperRange": 2,
+        "portionUnit": "servings"
+      },
+      "duration": {
+        "time": 15.0,
+        "timeUnit": "minutes"
+      },
+      "tags": [
+        "Italian"
+      ],
+      "ingredients": [
+        {
+          "ingredientName": "egg tagliolini",
+          "ingredientQuantity": "6 oz",
+          "remarks": [],
+          "substitutions": [
+            "spaghetti",
+            "bucatini"
+          ]
+        },
+        {
+          "ingredientName": "Pecorino",
+          "ingredientQuantity": "1/3 cup",
+          "remarks": [
+            "finely grated"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "unsalted butter",
+          "ingredientQuantity": "3 Tbsp",
+          "remarks": [
+            "cubed",
+            "divided"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Kosher salt",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Grana Padano",
+          "ingredientQuantity": "3/4 cup",
+          "remarks": [
+            "finely grated"
+          ],
+          "substitutions": [
+            "Parmesan"
+          ]
+        },
+        {
+          "ingredientName": "black pepper",
+          "ingredientQuantity": "1 tsp",
+          "remarks": [
+            "freshly cracked"
+          ],
+          "substitutions": []
+        }
+      ],
+      "steps": [
+        "Bring 3 quarts water to a boil in a 5-qt. pot. Season with salt; add pasta and cook, stirring occasionally, until about 2 minutes before tender. Drain, reserving 3/4 cup pasta cooking water.",
+        "Meanwhile, melt 2 Tbsp. butter in a Dutch oven or other large pot or skillet over medium heat. Add pepper and cook, swirling pan, until toasted, about 1 minute.",
+        "Add 0.5 cup reserved pasta water to skillet and bring to a simmer. Add pasta and remaining butter. Reduce heat to low and add Grana Padano, stirring and tossing with tongs until melted. Remove pan from heat; add Pecorino, stirring and tossing until cheese melts, sauce coats the pasta, and pasta is al dente. (Add more pasta water if sauce seems dry.) Transfer pasta to warm bowls and serve."
+      ]
     },
-    "duration" : {
-      "time" : 15.0,
-      "timeUnit" : "minutes"
+    {
+      "name": "American blueberry pancakes",
+      "portion": {
+        "lowerRange": 2,
+        "upperRange": 3,
+        "portionUnit": "servings"
+      },
+      "duration": {
+        "time": 35.0,
+        "timeUnit": "minutes"
+      },
+      "tags": [
+        "Breakfast",
+        "American"
+      ],
+      "ingredients": [
+        {
+          "ingredientName": "golden syrup",
+          "remarks": [],
+          "substitutions": [
+            "maple syrup"
+          ]
+        },
+        {
+          "ingredientName": "baking powder",
+          "ingredientQuantity": "1 tsp",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "sunflower oil",
+          "remarks": [
+            "a little"
+          ],
+          "substitutions": [
+            "butter"
+          ]
+        },
+        {
+          "ingredientName": "blueberries",
+          "ingredientQuantity": "150 g",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "egg",
+          "ingredientQuantity": "1",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "self-raising flour",
+          "ingredientQuantity": "200 g",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "butter",
+          "ingredientQuantity": "1 knob",
+          "remarks": [],
+          "substitutions": []
+        }
+      ],
+      "steps": [
+        "Mix together 200 g self-raising flour, 1 tsp baking powder and a pinch of salt in a large bowl.",
+        "Beat 1 egg with 300ml milk, make a well in the centre of the dry ingredients and whisk in the milk to make a thick smooth batter.",
+        "Beat in a knob of melted butter, and gently stir in half of the 150g pack of blueberries.",
+        "Heat a teaspoon of sunflower oil or small knob of butter in a large non-stick frying pan.",
+        "Drop a large tablespoonful of the batter per pancake into the pan to make pancakes about 7.5cm across. Make three or four pancakes at a time.",
+        "Cook for about 3 minutes over a medium heat until small bubbles appear on the surface of each pancake, then turn and cook another 2-3 minutes until golden.",
+        "Cover with kitchen paper to keep warm while you use up the rest of the batter.",
+        "Serve with golden or maple syrup and the rest of the blueberries."
+      ]
     },
-    "tags" : [ "Italian" ],
-    "ingredients" : [ {
-      "ingredientName" : "egg tagliolini",
-      "ingredientQuantity" : "6 oz",
-      "remarks" : [ ],
-      "substitutions" : [ "spaghetti", "bucatini" ]
-    }, {
-      "ingredientName" : "Pecorino",
-      "ingredientQuantity" : "1/3 cup",
-      "remarks" : [ "finely grated" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "unsalted butter",
-      "ingredientQuantity" : "3 Tbsp",
-      "remarks" : [ "cubed", "divided" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Kosher salt",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Grana Padano",
-      "ingredientQuantity" : "3/4 cup",
-      "remarks" : [ "finely grated" ],
-      "substitutions" : [ "Parmesan" ]
-    }, {
-      "ingredientName" : "black pepper",
-      "ingredientQuantity" : "1 tsp",
-      "remarks" : [ "freshly cracked" ],
-      "substitutions" : [ ]
-    } ],
-    "steps" : [ "Bring 3 quarts water to a boil in a 5-qt. pot. Season with salt; add pasta and cook, stirring occasionally, until about 2 minutes before tender. Drain, reserving 3/4 cup pasta cooking water.", "Meanwhile, melt 2 Tbsp. butter in a Dutch oven or other large pot or skillet over medium heat. Add pepper and cook, swirling pan, until toasted, about 1 minute.", "Add 0.5 cup reserved pasta water to skillet and bring to a simmer. Add pasta and remaining butter. Reduce heat to low and add Grana Padano, stirring and tossing with tongs until melted. Remove pan from heat; add Pecorino, stirring and tossing until cheese melts, sauce coats the pasta, and pasta is al dente. (Add more pasta water if sauce seems dry.) Transfer pasta to warm bowls and serve." ]
-  }, {
-    "name" : "American blueberry pancakes",
-    "portion" : {
-      "lowerRange" : 2,
-      "upperRange" : 3,
-      "portionUnit" : "servings"
+    {
+      "name": "Fish and Chips",
+      "portion": {
+        "lowerRange": 1,
+        "upperRange": 2,
+        "portionUnit": "servings"
+      },
+      "duration": {
+        "time": 10.0,
+        "timeUnit": "minutes"
+      },
+      "tags": [
+        "English",
+        "Comfort food"
+      ],
+      "ingredients": [
+        {
+          "ingredientName": "Self Rising Flour",
+          "ingredientQuantity": "120 Grams",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Potato",
+          "ingredientQuantity": "1",
+          "remarks": [
+            "Large",
+            "Waxy",
+            "Peeled"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Salt",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Creme Fraiche",
+          "ingredientQuantity": "50 Grams",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Mayonnaise",
+          "ingredientQuantity": "200 Grams",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Shallot",
+          "ingredientQuantity": "3/4",
+          "remarks": [
+            "Diced"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Egg White",
+          "ingredientQuantity": "1 Medium",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Baking Powder",
+          "ingredientQuantity": "1 Teaspoon",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Curry Powder",
+          "ingredientQuantity": "1 Teaspoon",
+          "remarks": [
+            "used twice"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Sunflower Oil",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Hot Sauce",
+          "remarks": [
+            "Optional"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Gherkins",
+          "ingredientQuantity": "1 Tablespoon",
+          "remarks": [
+            "chopped"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Light Beer",
+          "ingredientQuantity": "160 ML",
+          "estimatedQuantity": "0.5 cup",
+          "remarks": [],
+          "substitutions": [
+            "Lager"
+          ]
+        },
+        {
+          "ingredientName": "Cod",
+          "ingredientQuantity": "175 Grams",
+          "remarks": [],
+          "substitutions": [
+            "White Fleshed Fish"
+          ]
+        },
+        {
+          "ingredientName": "Lemon Juice",
+          "ingredientQuantity": "1 tsp",
+          "remarks": [],
+          "substitutions": []
+        }
+      ],
+      "steps": [
+        "Get oil in pan medium-high heat for frying before assembling ingredients. Do not need a deep pan or pot, a large pan will do",
+        "In a bowl whisk together flour, baking soda, curry powder and beer. Then whisk egg whites till there are stiff peaks and fold into batter (if too heavy add some water)",
+        "Add teaspoon of curry powder to dredging flour for more seasoning (optional)",
+        "Season fish with salt, then coat with flour. Knock off excess flour and put into batter mixture. Make sure fish is fully battered and ad to oil",
+        "Once fish is in, baste the fish with oil. Let first side cook until golden brown and flip. Basting fish with oil on other side. Take pan on and off oil so that the oil does not get too hot. Fish should be in oil 3-3.5 minutes. Once finished put on plate with paper towel and put in warm oven",
+        "Chop potato into square, then chop into tall skinny fries (the skinnier the fry the quicker they will cook). Then roll in paper towel to dry any excess moisture. Add new oil to pain then add potatoes to high heat. Once fries are browned, remove from oil on to paper towel and add salt.",
+        "Add all Tartar ingredients together and mix. Add salt to taste and hot sauce if you want heat.",
+        "Assemble together and enjoy!"
+      ]
     },
-    "duration" : {
-      "time" : 35.0,
-      "timeUnit" : "minutes"
+    {
+      "name": "Pan-fried camembert sandwich",
+      "portion": {
+        "lowerRange": 1,
+        "upperRange": 0,
+        "portionUnit": "portion"
+      },
+      "duration": {
+        "time": 4.0,
+        "timeUnit": "min"
+      },
+      "tags": [
+        "English",
+        "Comfort food"
+      ],
+      "ingredients": [
+        {
+          "ingredientName": "cranberry sauce",
+          "ingredientQuantity": "1 tbsp",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "camembert",
+          "ingredientQuantity": "a wedge",
+          "estimatedQuantity": "85g/3oz",
+          "remarks": [],
+          "substitutions": [
+            "brie"
+          ]
+        },
+        {
+          "ingredientName": "white bread",
+          "ingredientQuantity": "2 thick slices",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "balsamic vinegar",
+          "ingredientQuantity": "a few drops",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "butter",
+          "remarks": [],
+          "substitutions": []
+        }
+      ],
+      "steps": [
+        "Butter the bread. Put a wedge of camembert or brie on the unbuttered side of one slice of bread. Top with a spoonful of cranberry sauce. Drizzle with a few drops of balsamic vinegar, if you have some.",
+        "Put the second slice of bread on top, buttered side out. Fry in a hot non-stick pan, pressing down with a fish slice, for a minute or two on each side, until golden brown and melting. Cut in half and eat straightaway."
+      ]
     },
-    "tags" : [ "Breakfast", "American" ],
-    "ingredients" : [ {
-      "ingredientName" : "golden syrup",
-      "remarks" : [ ],
-      "substitutions" : [ "maple syrup" ]
-    }, {
-      "ingredientName" : "baking powder",
-      "ingredientQuantity" : "1 tsp",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "sunflower oil",
-      "remarks" : [ "a little" ],
-      "substitutions" : [ "butter" ]
-    }, {
-      "ingredientName" : "blueberries",
-      "ingredientQuantity" : "150 g",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "egg",
-      "ingredientQuantity" : "1",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "self-raising flour",
-      "ingredientQuantity" : "200 g",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "butter",
-      "ingredientQuantity" : "1 knob",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    } ],
-    "steps" : [ "Mix together 200 g self-raising flour, 1 tsp baking powder and a pinch of salt in a large bowl.", "Beat 1 egg with 300ml milk, make a well in the centre of the dry ingredients and whisk in the milk to make a thick smooth batter.", "Beat in a knob of melted butter, and gently stir in half of the 150g pack of blueberries.", "Heat a teaspoon of sunflower oil or small knob of butter in a large non-stick frying pan.", "Drop a large tablespoonful of the batter per pancake into the pan to make pancakes about 7.5cm across. Make three or four pancakes at a time.", "Cook for about 3 minutes over a medium heat until small bubbles appear on the surface of each pancake, then turn and cook another 2-3 minutes until golden.", "Cover with kitchen paper to keep warm while you use up the rest of the batter.", "Serve with golden or maple syrup and the rest of the blueberries." ]
-  }, {
-    "name" : "Fish and Chips",
-    "portion" : {
-      "lowerRange" : 1,
-      "upperRange" : 2,
-      "portionUnit" : "servings"
-    },
-    "duration" : {
-      "time" : 10.0,
-      "timeUnit" : "minutes"
-    },
-    "tags" : [ "English", "Comfort food" ],
-    "ingredients" : [ {
-      "ingredientName" : "Self Rising Flour",
-      "ingredientQuantity" : "120 Grams",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Potato",
-      "ingredientQuantity" : "1",
-      "remarks" : [ "Large", "Waxy", "Peeled" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Salt",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Creme Fraiche",
-      "ingredientQuantity" : "50 Grams",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Mayonnaise",
-      "ingredientQuantity" : "200 Grams",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Shallot",
-      "ingredientQuantity" : "3/4",
-      "remarks" : [ "Diced" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Egg White",
-      "ingredientQuantity" : "1 Medium",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Baking Powder",
-      "ingredientQuantity" : "1 Teaspoon",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Curry Powder",
-      "ingredientQuantity" : "1 Teaspoon",
-      "remarks" : [ "used twice" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Sunflower Oil",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Hot Sauce",
-      "remarks" : [ "Optional" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Gherkins",
-      "ingredientQuantity" : "1 Tablespoon",
-      "remarks" : [ "chopped" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Light Beer",
-      "ingredientQuantity" : "160 ML",
-      "estimatedQuantity" : "0.5 cup",
-      "remarks" : [ ],
-      "substitutions" : [ "Lager" ]
-    }, {
-      "ingredientName" : "Cod",
-      "ingredientQuantity" : "175 Grams",
-      "remarks" : [ ],
-      "substitutions" : [ "White Fleshed Fish" ]
-    }, {
-      "ingredientName" : "Lemon Juice",
-      "ingredientQuantity" : "1 tsp",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    } ],
-    "steps" : [ "Get oil in pan medium-high heat for frying before assembling ingredients. Do not need a deep pan or pot, a large pan will do", "In a bowl whisk together flour, baking soda, curry powder and beer. Then whisk egg whites till there are stiff peaks and fold into batter (if too heavy add some water)", "Add teaspoon of curry powder to dredging flour for more seasoning (optional)", "Season fish with salt, then coat with flour. Knock off excess flour and put into batter mixture. Make sure fish is fully battered and ad to oil", "Once fish is in, baste the fish with oil. Let first side cook until golden brown and flip. Basting fish with oil on other side. Take pan on and off oil so that the oil does not get too hot. Fish should be in oil 3-3.5 minutes. Once finished put on plate with paper towel and put in warm oven", "Chop potato into square, then chop into tall skinny fries (the skinnier the fry the quicker they will cook). Then roll in paper towel to dry any excess moisture. Add new oil to pain then add potatoes to high heat. Once fries are browned, remove from oil on to paper towel and add salt.", "Add all Tartar ingredients together and mix. Add salt to taste and hot sauce if you want heat.", "Assemble together and enjoy!" ]
-  }, {
-    "name" : "Pan-fried camembert sandwich",
-    "portion" : {
-      "lowerRange" : 1,
-      "upperRange" : -2147483648,
-      "portionUnit" : "portion"
-    },
-    "duration" : {
-      "time" : 4.0,
-      "timeUnit" : "min"
-    },
-    "tags" : [ "English", "Comfort food" ],
-    "ingredients" : [ {
-      "ingredientName" : "cranberry sauce",
-      "ingredientQuantity" : "1 tbsp",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "camembert",
-      "ingredientQuantity" : "a wedge",
-      "estimatedQuantity" : "85g/3oz",
-      "remarks" : [ ],
-      "substitutions" : [ "brie" ]
-    }, {
-      "ingredientName" : "white bread",
-      "ingredientQuantity" : "2 thick slices",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "balsamic vinegar",
-      "ingredientQuantity" : "a few drops",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "butter",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    } ],
-    "steps" : [ "Butter the bread. Put a wedge of camembert or brie on the unbuttered side of one slice of bread. Top with a spoonful of cranberry sauce. Drizzle with a few drops of balsamic vinegar, if you have some.", "Put the second slice of bread on top, buttered side out. Fry in a hot non-stick pan, pressing down with a fish slice, for a minute or two on each side, until golden brown and melting. Cut in half and eat straightaway." ]
-  }, {
-    "name" : "Classic Masala Dosa",
-    "portion" : {
-      "lowerRange" : 8,
-      "upperRange" : 10,
-      "portionUnit" : "servings"
-    },
-    "duration" : {
-      "time" : 1.0,
-      "timeUnit" : "hour"
-    },
-    "tags" : [ "Indian" ],
-    "ingredients" : [ {
-      "ingredientName" : "Yukon Gold potatoes",
-      "ingredientQuantity" : "1.5 pounds",
-      "remarks" : [ "boiled", "peeled", "cubed" ],
-      "substitutions" : [ "yellow-fleshed potatoes" ]
-    }, {
-      "ingredientName" : "red peppers",
-      "ingredientQuantity" : "2",
-      "remarks" : [ "small", "dried", "hot" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "ghee",
-      "ingredientQuantity" : "3 tablespoons",
-      "remarks" : [ ],
-      "substitutions" : [ "vegetable oil" ]
-    }, {
-      "ingredientName" : "asafetida",
-      "ingredientQuantity" : "a pinch",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "mustard seeds",
-      "ingredientQuantity" : "1 teaspoon",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "garlic cloves",
-      "ingredientQuantity" : "4",
-      "remarks" : [ "minced" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "small green chilli",
-      "ingredientQuantity" : "2",
-      "remarks" : [ "finely chopped" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "curry leaves",
-      "ingredientQuantity" : "6 to 8",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "onion",
-      "ingredientQuantity" : "1",
-      "remarks" : [ "medium", "diced" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "cilantro",
-      "ingredientQuantity" : "1/2 cup",
-      "remarks" : [ "leaves", "tender stems", "roughly chopped" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "cumin seeds",
-      "ingredientQuantity" : "1/2 teaspoon",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "fenugreek seeds",
-      "ingredientQuantity" : "1 teaspoon",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "Vegetable oil",
-      "remarks" : [ "for frying" ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "turmeric",
-      "ingredientQuantity" : "1/2 teaspoon",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "short-grain rice",
-      "ingredientQuantity" : "2 cups",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "urad dal",
-      "commonName" : "split husked black lentils",
-      "ingredientQuantity" : "1/2 cup",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "salt",
-      "ingredientQuantity" : "1/2 teaspoon",
-      "remarks" : [ ],
-      "substitutions" : [ ]
-    }, {
-      "ingredientName" : "ginger",
-      "ingredientQuantity" : "1 tablespoon",
-      "remarks" : [ "grated" ],
-      "substitutions" : [ ]
-    } ],
-    "steps" : [ "Make the dosa batter: Put rice in a bowl, rinse well and cover with 4 cups cold water. Put urad dal and fenugreek seeds in a small bowl, rinse well and add cold water to cover. Leave both to soak for 4 to 6 hours.", "Drain rice and dal-fenugreek mixture in separate colanders. Put rice in a food processor, blender or wet-dry grinder. Add 1 cup cold water and grind to a smooth paste. It will take about 10 minutes, and it may be necessary to work in batches. Repeat the process with the dal-fenugreek mixture.", "Combine the two pastes in a medium mixing bowl. Whisk together, adding enough water to obtain a medium-thick batter. You should have about 6 cups. Cover bowl with a kitchen towel and set in a warm place. Let ferment until the surface is bubbly, about 8 hours. Stir in the salt. Use the batter straight away or refrigerate for later use. (Batter will keep for up to a week, refrigerated. Thin with water if necessary before proceeding.)", "Make the potato filling: Put ghee in a wide skillet over medium heat. When oil is wavy, add mustard seeds and cumin seeds. Wait for seeds to pop, about 1 minute, then add red peppers and onion. Cook, stirring until onions have softened, about 5 minutes. Season lightly with salt. Add turmeric, asafetida, ginger,curry leaves, garlic and green chile. Stir to coat and let sizzle for 1 minute.", "Add potatoes and 0.5 cup water. Cook, stirring well to combine, until liquid has evaporated, about 5 minutes. Mash potatoes a bit with the back of a wooden spoon. Season well with salt, add cilantro, then set aside at roomtemperature. (Potato filling may be prepared up to a day in advance.)", "To make dosas, set a griddle or cast-iron skillet over medium heat. Brush with about 1 teaspoon vegetable oil. Ladle 1/4 cup batter in the center of griddle. Using bottom of ladle, quickly spread batter outward in a circular motion to a diameter of about 7 inches. Drizzle 0.5 teaspoon oil over the top. Leave dosa batter to brown gradually until outer edges begin to look dry, about 2 minutes, cooking on one side only. With a spatula, carefully loosen dosa from griddle. Bottom should be crisp and beautifully browned. Spoon 0.5 cup potato filling onto top of dosa, centering it as a strip in the middle of the round dosa. Flatten the potato mixture slightly. Using the spatula, fold the sides of the dosa around the filling to make a cylindrical shape. Serve immediately. Continue making dosas one at a time." ]
-  } ]
+    {
+      "name": "Classic Masala Dosa",
+      "portion": {
+        "lowerRange": 8,
+        "upperRange": 10,
+        "portionUnit": "servings"
+      },
+      "duration": {
+        "time": 1.0,
+        "timeUnit": "hour"
+      },
+      "tags": [
+        "Indian"
+      ],
+      "ingredients": [
+        {
+          "ingredientName": "Yukon Gold potatoes",
+          "ingredientQuantity": "1.5 pounds",
+          "remarks": [
+            "boiled",
+            "peeled",
+            "cubed"
+          ],
+          "substitutions": [
+            "yellow-fleshed potatoes"
+          ]
+        },
+        {
+          "ingredientName": "red peppers",
+          "ingredientQuantity": "2",
+          "remarks": [
+            "small",
+            "dried",
+            "hot"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "ghee",
+          "ingredientQuantity": "3 tablespoons",
+          "remarks": [],
+          "substitutions": [
+            "vegetable oil"
+          ]
+        },
+        {
+          "ingredientName": "asafetida",
+          "ingredientQuantity": "a pinch",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "mustard seeds",
+          "ingredientQuantity": "1 teaspoon",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "garlic cloves",
+          "ingredientQuantity": "4",
+          "remarks": [
+            "minced"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "small green chilli",
+          "ingredientQuantity": "2",
+          "remarks": [
+            "finely chopped"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "curry leaves",
+          "ingredientQuantity": "6 to 8",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "onion",
+          "ingredientQuantity": "1",
+          "remarks": [
+            "medium",
+            "diced"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "cilantro",
+          "ingredientQuantity": "1/2 cup",
+          "remarks": [
+            "leaves",
+            "tender stems",
+            "roughly chopped"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "cumin seeds",
+          "ingredientQuantity": "1/2 teaspoon",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "fenugreek seeds",
+          "ingredientQuantity": "1 teaspoon",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "Vegetable oil",
+          "remarks": [
+            "for frying"
+          ],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "turmeric",
+          "ingredientQuantity": "1/2 teaspoon",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "short-grain rice",
+          "ingredientQuantity": "2 cups",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "urad dal",
+          "commonName": "split husked black lentils",
+          "ingredientQuantity": "1/2 cup",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "salt",
+          "ingredientQuantity": "1/2 teaspoon",
+          "remarks": [],
+          "substitutions": []
+        },
+        {
+          "ingredientName": "ginger",
+          "ingredientQuantity": "1 tablespoon",
+          "remarks": [
+            "grated"
+          ],
+          "substitutions": []
+        }
+      ],
+      "steps": [
+        "Make the dosa batter: Put rice in a bowl, rinse well and cover with 4 cups cold water. Put urad dal and fenugreek seeds in a small bowl, rinse well and add cold water to cover. Leave both to soak for 4 to 6 hours.",
+        "Drain rice and dal-fenugreek mixture in separate colanders. Put rice in a food processor, blender or wet-dry grinder. Add 1 cup cold water and grind to a smooth paste. It will take about 10 minutes, and it may be necessary to work in batches. Repeat the process with the dal-fenugreek mixture.",
+        "Combine the two pastes in a medium mixing bowl. Whisk together, adding enough water to obtain a medium-thick batter. You should have about 6 cups. Cover bowl with a kitchen towel and set in a warm place. Let ferment until the surface is bubbly, about 8 hours. Stir in the salt. Use the batter straight away or refrigerate for later use. (Batter will keep for up to a week, refrigerated. Thin with water if necessary before proceeding.)",
+        "Make the potato filling: Put ghee in a wide skillet over medium heat. When oil is wavy, add mustard seeds and cumin seeds. Wait for seeds to pop, about 1 minute, then add red peppers and onion. Cook, stirring until onions have softened, about 5 minutes. Season lightly with salt. Add turmeric, asafetida, ginger,curry leaves, garlic and green chile. Stir to coat and let sizzle for 1 minute.",
+        "Add potatoes and 0.5 cup water. Cook, stirring well to combine, until liquid has evaporated, about 5 minutes. Mash potatoes a bit with the back of a wooden spoon. Season well with salt, add cilantro, then set aside at roomtemperature. (Potato filling may be prepared up to a day in advance.)",
+        "To make dosas, set a griddle or cast-iron skillet over medium heat. Brush with about 1 teaspoon vegetable oil. Ladle 1/4 cup batter in the center of griddle. Using bottom of ladle, quickly spread batter outward in a circular motion to a diameter of about 7 inches. Drizzle 0.5 teaspoon oil over the top. Leave dosa batter to brown gradually until outer edges begin to look dry, about 2 minutes, cooking on one side only. With a spatula, carefully loosen dosa from griddle. Bottom should be crisp and beautifully browned. Spoon 0.5 cup potato filling onto top of dosa, centering it as a strip in the middle of the round dosa. Flatten the potato mixture slightly. Using the spatula, fold the sides of the dosa around the filling to make a cylindrical shape. Serve immediately. Continue making dosas one at a time."
+      ]
+    }
+  ]
 }

--- a/src/test/java/seedu/recipe/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/recipe/logic/parser/ParserUtilTest.java
@@ -9,6 +9,7 @@ import static seedu.recipe.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -19,7 +20,9 @@ import seedu.recipe.logic.parser.exceptions.ParseException;
 import seedu.recipe.model.recipe.Name;
 import seedu.recipe.model.recipe.RecipePortion;
 import seedu.recipe.model.recipe.Step;
+import seedu.recipe.model.recipe.ingredient.Ingredient;
 import seedu.recipe.model.recipe.ingredient.IngredientBuilder;
+import seedu.recipe.model.recipe.ingredient.IngredientInformation;
 import seedu.recipe.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -39,10 +42,10 @@ public class ParserUtilTest {
     private static final String VALID_INGREDIENT_1 = "-a 1 pound -n lasagna sheets";
     private static final String VALID_INGREDIENT_2 = "-a 1 teaspoon -n salt";
     private static final String VALID_STEP_1 =
-            "Cook the lasagna noodles according to the package instructions. Drain and set aside.";
+        "Cook the lasagna noodles according to the package instructions. Drain and set aside.";
     private static final String VALID_STEP_2 =
-            "Add the crushed tomatoes, tomato paste, basil, oregano, salt, and black pepper to the skillet. "
-                    + "Stir to combine and simmer for 10-15 minutes.";
+        "Add the crushed tomatoes, tomato paste, basil, oregano, salt, and black pepper to the skillet. "
+            + "Stir to combine and simmer for 10-15 minutes.";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -54,7 +57,7 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test
@@ -199,7 +202,7 @@ public class ParserUtilTest {
     @Test
     public void parseIngredients_collectionWithInvalidIngredients_throwsParseException() {
         assertThrows(ParseException.class, () ->
-                ParserUtil.parseIngredients(Arrays.asList(VALID_INGREDIENT_1, INVALID_INGREDIENT)));
+            ParserUtil.parseIngredients(Arrays.asList(VALID_INGREDIENT_1, INVALID_INGREDIENT)));
     }
 
     @Test
@@ -209,11 +212,14 @@ public class ParserUtilTest {
 
     @Test
     public void parseIngredients_collectionWithValidIngredients_returnsIngredientsList() throws Exception {
-        List<IngredientBuilder> actualIngredientList =
-                ParserUtil.parseIngredients(Arrays.asList(VALID_INGREDIENT_1, VALID_INGREDIENT_2));
-        List<IngredientBuilder> expectedIngredientList =
-                new ArrayList<IngredientBuilder>(Arrays.asList(new IngredientBuilder(VALID_INGREDIENT_1),
-                                                        new IngredientBuilder(VALID_INGREDIENT_2)));
+        HashMap<Ingredient, IngredientInformation> actualIngredientList =
+            ParserUtil.parseIngredients(Arrays.asList(VALID_INGREDIENT_1, VALID_INGREDIENT_2));
+
+        HashMap<Ingredient, IngredientInformation> expectedIngredientList = new HashMap<>();
+        HashMap<Ingredient, IngredientInformation> ingredient1 = new IngredientBuilder(VALID_INGREDIENT_1).build();
+        HashMap<Ingredient, IngredientInformation> ingredient2 = new IngredientBuilder(VALID_INGREDIENT_2).build();
+        expectedIngredientList.putAll(ingredient1);
+        expectedIngredientList.putAll(ingredient2);
 
         assertEquals(expectedIngredientList, actualIngredientList);
     }
@@ -243,7 +249,7 @@ public class ParserUtilTest {
     @Test
     public void parseSteps_collectionWithInvalidSteps_throwsParseException() {
         assertThrows(ParseException.class, () ->
-                ParserUtil.parseSteps(Arrays.asList(VALID_STEP_1, INVALID_STEP)));
+            ParserUtil.parseSteps(Arrays.asList(VALID_STEP_1, INVALID_STEP)));
     }
 
     @Test
@@ -254,10 +260,10 @@ public class ParserUtilTest {
     @Test
     public void parseSteps_collectionWithValidSteps_returnsStepsList() throws Exception {
         List<Step> actualStepList =
-                ParserUtil.parseSteps(Arrays.asList(VALID_STEP_1, VALID_STEP_2));
+            ParserUtil.parseSteps(Arrays.asList(VALID_STEP_1, VALID_STEP_2));
         List<Step> expectedStepList =
-                new ArrayList<Step>(Arrays.asList(new Step(VALID_STEP_1),
-                                                  new Step(VALID_STEP_2)));
+            new ArrayList<Step>(Arrays.asList(new Step(VALID_STEP_1),
+                new Step(VALID_STEP_2)));
 
         assertEquals(expectedStepList, actualStepList);
     }

--- a/src/test/java/seedu/recipe/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/recipe/logic/parser/ParserUtilTest.java
@@ -183,14 +183,16 @@ public class ParserUtilTest {
 
     @Test
     public void parseIngredient_validValueWithoutWhitespace_returnsIngredient() throws Exception {
-        IngredientBuilder expectedIngredient = new IngredientBuilder(VALID_INGREDIENT_1);
+        HashMap<Ingredient, IngredientInformation> expectedIngredient = new IngredientBuilder(
+            VALID_INGREDIENT_1).build();
         assertEquals(expectedIngredient, ParserUtil.parseIngredient(VALID_INGREDIENT_1));
     }
 
     @Test
     public void parseIngredient_validValueWithWhitespace_returnsTrimmedIngredient() throws Exception {
         String ingredientWithWhitespace = WHITESPACE + VALID_INGREDIENT_1 + WHITESPACE;
-        IngredientBuilder expectedIngredient = new IngredientBuilder(VALID_INGREDIENT_1);
+        HashMap<Ingredient, IngredientInformation> expectedIngredient = new IngredientBuilder(
+            VALID_INGREDIENT_1).build();
         assertEquals(expectedIngredient, ParserUtil.parseIngredient(ingredientWithWhitespace));
     }
 

--- a/src/test/java/seedu/recipe/model/recipe/NameTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/NameTest.java
@@ -38,10 +38,10 @@ public class NameTest {
         assertFalse(Name.isValidName(WHITESPACE));
         assertFalse(Name.isValidName(NON_VALID_CHAR_SOLO));
         assertFalse(Name.isValidName(NON_VALID_CHAR));
-        assertFalse(Name.isValidName(NUMBER_ONLY));
-        assertFalse(Name.isValidName(HYPHEN_ONLY));
 
         // valid name
+        assertTrue(Name.isValidName(NUMBER_ONLY));
+        assertTrue(Name.isValidName(HYPHEN_ONLY));
         assertTrue(Name.isValidName(ONE_TOKEN_ALPHA));
         assertTrue(Name.isValidName(MULTI_TOKEN_ALPHA));
         assertTrue(Name.isValidName(SINGLE_NUMBER_LEADING));

--- a/src/test/java/seedu/recipe/model/recipe/RecipeDurationTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/RecipeDurationTest.java
@@ -16,7 +16,6 @@ public class RecipeDurationTest {
 
     private static final String VALID_MULTIPLE_WHITESPACE_BETWEEN = "38.7        units";
     private static final String VALID_MULTIPLE_WORDS_UNIT = "321/22 Word onE twO three";
-    private static final String VALID_LEADING_TRAILING_WHITESPACE = "       3912   seconds       ";
 
     private static final String INVALID_NO_TIME = "years";
     private static final String INVALID_NO_UNIT = "908.2098";
@@ -27,27 +26,19 @@ public class RecipeDurationTest {
     private static final String INVALID_DECIMAL_NO_WHITESPACE = "0.00012years";
     private static final String INVALID_FRACTION_NO_WHITESPACE = "312/32891798timeunits";
 
-    private static final String INVALID_WHITESPACE_BETWEEN = "1321\nsample time units";
     private static final String INVALID_WHITESPACE_IN_UNIT = "321 example\ntime units";
     private static final String INVALID_CHARACTERS_IN_UNIT = "213.10000 Cycles of_the Earth's Rotation";
-
-    @Test
-    public void test_null_constructor() {
-        assertThrows(NullPointerException.class, () -> new RecipeDuration(0, null));
-    }
 
     @Test
     public void of_validInputs_RecipeDurationCreated() {
         assertEquals(RecipeDuration.of(VALID_INTEGER), new RecipeDuration(1, new TimeUnit("hour")));
         assertEquals(RecipeDuration.of(VALID_DECIMAL), new RecipeDuration(0.00012, new TimeUnit("years")));
-        assertEquals(RecipeDuration.of(VALID_FRACTION), new RecipeDuration(13 / 213, new TimeUnit("days")));
+        assertEquals(RecipeDuration.of(VALID_FRACTION), new RecipeDuration(((double) 13) / 213, new TimeUnit("days")));
 
         assertEquals(RecipeDuration.of(VALID_MULTIPLE_WHITESPACE_BETWEEN),
             new RecipeDuration(38.7, new TimeUnit("units")));
         assertEquals(RecipeDuration.of(VALID_MULTIPLE_WORDS_UNIT),
-            new RecipeDuration(321 / 22, new TimeUnit("Word onE twO three")));
-        assertEquals(RecipeDuration.of(VALID_LEADING_TRAILING_WHITESPACE),
-            new RecipeDuration(3912, new TimeUnit("seconds")));
+            new RecipeDuration(((double) 321) / 22, new TimeUnit("Word onE twO three")));
     }
 
     @Test
@@ -61,15 +52,8 @@ public class RecipeDurationTest {
         assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_DECIMAL_NO_WHITESPACE));
         assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_FRACTION_NO_WHITESPACE));
 
-        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_WHITESPACE_BETWEEN));
         assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_WHITESPACE_IN_UNIT));
         assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_CHARACTERS_IN_UNIT));
-    }
-
-    @Test
-    public void testWrongArgumentsConstructor() {
-        assertThrows(IllegalArgumentException.class, () -> new RecipeDuration(0.00, new TimeUnit("hour")));
-        assertThrows(IllegalArgumentException.class, () -> new RecipeDuration(-1.00, new TimeUnit("hour")));
     }
 
     @Test

--- a/src/test/java/seedu/recipe/model/recipe/RecipeDurationTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/RecipeDurationTest.java
@@ -1,42 +1,35 @@
 package seedu.recipe.model.recipe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.recipe.model.recipe.exceptions.RecipeDurationInvalidArgumentLengthException;
-import seedu.recipe.model.recipe.exceptions.RecipeDurationInvalidDurationException;
 import seedu.recipe.model.recipe.unit.TimeUnit;
 
 public class RecipeDurationTest {
-    private static final String VALID_SIMPLE = "1 hour";
-    private static final String VALID_PLURAL = "2 hours";
-    private static final String DECIMAL_PLURAL_END = "1.5 hours";
-    private static final String DECIMAL_LT_ONE = "0.005 hours";
-    private static final String VALID_DECIMAL = "10.000 hours";
-    private static final String SECONDS = "30 seconds";
-    private static final String MINUTES = "25 minutes";
-    private static final String DAY = "1 day";
+    private static final String VALID_INTEGER = "1 hour";
+    private static final String VALID_DECIMAL = "0.00012 years";
+    private static final String VALID_FRACTION = "13/213 days";
 
-    private static final String SINGLE_PLURAL_END = "1 hours";
-    private static final String INVALID_UNIT = "1 run";
-    private static final String INVALID_FRACTION = "1/2 hour";
-    private static final String NO_NUMBER = "hour";
-    private static final String ZERO_DECIMAL = "0.000 hours";
-    private static final String NO_WHITESPACE = "1hour";
-    private static final String LONG_DECIMAL = "1.0000 hours";
-    private static final String LONG_DECIMAL_2 = "2.0000 hours";
-    private static final String LARGE_NUM_2 = "2000 hours";
-    private static final String LARGE_NUM = "1000 hours";
-    private static final String NON_ONE_NON_PLURAL = "10 hour";
+    private static final String VALID_MULTIPLE_WHITESPACE_BETWEEN = "38.7        units";
+    private static final String VALID_MULTIPLE_WORDS_UNIT = "321/22 Word onE twO three";
+    private static final String VALID_LEADING_TRAILING_WHITESPACE = "       3912   seconds       ";
 
-    //Future support is intended for this, but the recipe duration should be a fixed estimate.
-    private static final String RANGE_UNIT = "2 - 3 hours";
+    private static final String INVALID_NO_TIME = "years";
+    private static final String INVALID_NO_UNIT = "908.2098";
+    private static final String INVALID_DECIMAL_WHITESPACE = "0 . 1233 units";
+    private static final String INVALID_FRACTION_WHITESPACE = "1321 /   123     sample tesTing";
+
+    private static final String INVALID_INTEGER_NO_WHITESPACE = "1hour";
+    private static final String INVALID_DECIMAL_NO_WHITESPACE = "0.00012years";
+    private static final String INVALID_FRACTION_NO_WHITESPACE = "312/32891798timeunits";
+
+    private static final String INVALID_WHITESPACE_BETWEEN = "1321\nsample time units";
+    private static final String INVALID_WHITESPACE_IN_UNIT = "321 example\ntime units";
+    private static final String INVALID_CHARACTERS_IN_UNIT = "213.10000 Cycles of_the Earth's Rotation";
 
     @Test
     public void test_null_constructor() {
@@ -44,28 +37,33 @@ public class RecipeDurationTest {
     }
 
     @Test
-    public void test_regex() {
-        assertFalse(RecipeDuration.isValidRecipeDuration(INVALID_UNIT));
-        assertFalse(RecipeDuration.isValidRecipeDuration(SINGLE_PLURAL_END));
-        assertFalse(RecipeDuration.isValidRecipeDuration(RANGE_UNIT));
-        assertFalse(RecipeDuration.isValidRecipeDuration(INVALID_FRACTION));
-        assertFalse(RecipeDuration.isValidRecipeDuration(NO_NUMBER));
-        assertFalse(RecipeDuration.isValidRecipeDuration(ZERO_DECIMAL));
-        assertFalse(RecipeDuration.isValidRecipeDuration(NO_WHITESPACE));
-        assertFalse(RecipeDuration.isValidRecipeDuration(LONG_DECIMAL));
-        assertFalse(RecipeDuration.isValidRecipeDuration(LONG_DECIMAL_2));
-        assertFalse(RecipeDuration.isValidRecipeDuration(LARGE_NUM));
-        assertFalse(RecipeDuration.isValidRecipeDuration(LARGE_NUM_2));
-        assertFalse(RecipeDuration.isValidRecipeDuration(NON_ONE_NON_PLURAL));
+    public void of_validInputs_RecipeDurationCreated() {
+        assertEquals(RecipeDuration.of(VALID_INTEGER), new RecipeDuration(1, new TimeUnit("hour")));
+        assertEquals(RecipeDuration.of(VALID_DECIMAL), new RecipeDuration(0.00012, new TimeUnit("years")));
+        assertEquals(RecipeDuration.of(VALID_FRACTION), new RecipeDuration(13 / 213, new TimeUnit("days")));
 
-        assertTrue(RecipeDuration.isValidRecipeDuration(VALID_DECIMAL));
-        assertTrue(RecipeDuration.isValidRecipeDuration(VALID_SIMPLE));
-        assertTrue(RecipeDuration.isValidRecipeDuration(VALID_PLURAL));
-        assertTrue(RecipeDuration.isValidRecipeDuration(DECIMAL_PLURAL_END));
-        assertTrue(RecipeDuration.isValidRecipeDuration(DECIMAL_LT_ONE));
-        assertTrue(RecipeDuration.isValidRecipeDuration(DAY));
-        assertTrue(RecipeDuration.isValidRecipeDuration(MINUTES));
-        assertTrue(RecipeDuration.isValidRecipeDuration(SECONDS));
+        assertEquals(RecipeDuration.of(VALID_MULTIPLE_WHITESPACE_BETWEEN),
+            new RecipeDuration(38.7, new TimeUnit("units")));
+        assertEquals(RecipeDuration.of(VALID_MULTIPLE_WORDS_UNIT),
+            new RecipeDuration(321 / 22, new TimeUnit("Word onE twO three")));
+        assertEquals(RecipeDuration.of(VALID_LEADING_TRAILING_WHITESPACE),
+            new RecipeDuration(3912, new TimeUnit("seconds")));
+    }
+
+    @Test
+    public void of_invalidInputs_exceptionThrown() {
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_NO_TIME));
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_NO_UNIT));
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_DECIMAL_WHITESPACE));
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_FRACTION_WHITESPACE));
+
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_INTEGER_NO_WHITESPACE));
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_DECIMAL_NO_WHITESPACE));
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_FRACTION_NO_WHITESPACE));
+
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_WHITESPACE_BETWEEN));
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_WHITESPACE_IN_UNIT));
+        assertThrows(IllegalArgumentException.class, () -> RecipeDuration.of(INVALID_CHARACTERS_IN_UNIT));
     }
 
     @Test
@@ -77,20 +75,6 @@ public class RecipeDurationTest {
     @Test
     public void test_toString() {
         assertEquals("1.0 hour", new RecipeDuration(1, new TimeUnit("hour")).toString());
-    }
-
-    @Test
-    public void testFactory() {
-        //Too few arguments
-        assertThrows(RecipeDurationInvalidArgumentLengthException.class, () -> RecipeDuration.of(NO_WHITESPACE));
-        //Too many arguments
-        assertThrows(
-            RecipeDurationInvalidArgumentLengthException.class, (
-            ) -> RecipeDuration.of("13 days in the winter"));
-        //Invalid duration
-        assertThrows(RecipeDurationInvalidDurationException.class, () -> RecipeDuration.of(INVALID_FRACTION));
-        assertEquals(RecipeDuration.of(VALID_PLURAL).toString(),
-                     new RecipeDuration(2, new TimeUnit("hours")).toString());
     }
 
     @Test

--- a/src/test/java/seedu/recipe/model/recipe/RecipeDurationTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/RecipeDurationTest.java
@@ -30,7 +30,7 @@ public class RecipeDurationTest {
     private static final String INVALID_CHARACTERS_IN_UNIT = "213.10000 Cycles of_the Earth's Rotation";
 
     @Test
-    public void of_validInputs_RecipeDurationCreated() {
+    public void of_validInputs_recipeDurationCreated() {
         assertEquals(RecipeDuration.of(VALID_INTEGER), new RecipeDuration(1, new TimeUnit("hour")));
         assertEquals(RecipeDuration.of(VALID_DECIMAL), new RecipeDuration(0.00012, new TimeUnit("years")));
         assertEquals(RecipeDuration.of(VALID_FRACTION), new RecipeDuration(((double) 13) / 213, new TimeUnit("days")));

--- a/src/test/java/seedu/recipe/model/recipe/RecipePortionTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/RecipePortionTest.java
@@ -1,6 +1,5 @@
 package seedu.recipe.model.recipe;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.recipe.testutil.Assert.assertThrows;
 
@@ -26,13 +25,7 @@ public class RecipePortionTest {
     private static final String INVALID_SIMPLE = "3.123 servings";
     private static final String INVALID_DASH = "1.5 - 3321 servings";
     private static final String INVALID_TO = "2    to 33.21 servings";
-    private static final String INVALID_WHITESPACE = "1321\tservings";
     private static final String INVALID_UNIT = "13 - 15 of Granny's Friends";
-
-    @Test
-    public void test_null_constructor() {
-        assertThrows(NullPointerException.class, () -> new RecipePortion(0, 0, null));
-    }
 
     @Test
     public void of_validInputs_RecipePortionCreated() {
@@ -53,25 +46,14 @@ public class RecipePortionTest {
         assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_EMPTY));
         assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_DASH));
         assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_TO));
-        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_WHITESPACE));
         assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_UNIT));
 
     }
 
     @Test
-    public void testConstructorValid() {
-        //Redirection if invalid params
-        assertThrows(IllegalArgumentException.class, () -> new RecipePortion(0, 0, new PortionUnit("min")));
-
-        assertDoesNotThrow(() -> new RecipePortion(1, -1, new PortionUnit("serving")));
-        assertDoesNotThrow(() -> new RecipePortion(1, 3, new PortionUnit("portions")));
-    }
-
-
-    @Test
     public void testToString() {
         assertEquals(
-            new RecipePortion(1, -1, new PortionUnit("portion")).toString(), "1 portion");
+            new RecipePortion(1, 0, new PortionUnit("portion")).toString(), "1 portion");
         assertEquals(new RecipePortion(1, 3, new PortionUnit("portions")).toString(), "1 - 3 portions");
     }
 
@@ -87,7 +69,7 @@ public class RecipePortionTest {
         assertEquals(new RecipePortion(1, 3, p).getPortionUnit(), p);
         assertEquals(new RecipePortion(1, 3, p).getUpperRange(), 3);
         assertEquals(new RecipePortion(1, 3, p).getLowerRange(), 1);
-        assertEquals(new RecipePortion(1, -1, new PortionUnit("portion")).getLowerRange(), 1);
-        assertEquals(new RecipePortion(1, -1, new PortionUnit("portion")).getUpperRange(), -1);
+        assertEquals(new RecipePortion(1, 0, new PortionUnit("portion")).getLowerRange(), 1);
+        assertEquals(new RecipePortion(1, 0, new PortionUnit("portion")).getUpperRange(), 0);
     }
 }

--- a/src/test/java/seedu/recipe/model/recipe/RecipePortionTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/RecipePortionTest.java
@@ -2,29 +2,32 @@ package seedu.recipe.model.recipe;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.recipe.testutil.Assert.assertThrows;
 
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.recipe.model.recipe.exceptions.RecipePortionInvalidArgumentException;
 import seedu.recipe.model.recipe.unit.PortionUnit;
 
 public class RecipePortionTest {
-    private static final String RANGE_CONCAT = "1-2 servings";
-    private static final String RANGE_WHITESPACE = "1  - 2 servings";
-    private static final String TO_WHITESPACE = "1 to 2 servings";
-    private static final String SIMPLE_LOWER_RANGE = "1 serving";
-    private static final String SIMPLE_LOWER_RANGE_PLURAL = "2 servings";
+    // valid cases
+    private static final String DASH_CONCAT = "1-2 servings";
+    private static final String TO_CONCAT = "1-2 servings";
+    private static final String DASH_WHITESPACE = "1  - 2 servings";
+    private static final String TO_WHITESPACE = "1 to   2 people";
+    private static final String SIMPLE_LOWER_RANGE = "13 serving sizes";
 
-    private static final String EMPTY = "";
-    private static final String SINGLE_PLURAL_ADDEND = "1 servings";
-    private static final String PLURAL_NO_ADDEND = "2 portion";
-    private static final String TO_NO_WHITESPACE = "1to2 servings";
+    // invalid cases
+    private static final String INVALID_EMPTY = "";
+    private static final String INVALID_NO_RANGE = "people pleasers";
+    private static final String INVALID_NO_UNIT = "3 to 5";
     private static final String INVALID_RANGE = "3 to 1 servings";
+    private static final String INVALID_SIMPLE = "3.123 servings";
+    private static final String INVALID_DASH = "1.5 - 3321 servings";
+    private static final String INVALID_TO = "2    to 33.21 servings";
+    private static final String INVALID_WHITESPACE = "1321\tservings";
+    private static final String INVALID_UNIT = "13 - 15 of Granny's Friends";
 
     @Test
     public void test_null_constructor() {
@@ -32,18 +35,27 @@ public class RecipePortionTest {
     }
 
     @Test
-    public void isValidRecipePortion() {
-        assertFalse(RecipePortion.isValidRecipePortion(EMPTY));
-        assertFalse(RecipePortion.isValidRecipePortion(SINGLE_PLURAL_ADDEND));
-        assertFalse(RecipePortion.isValidRecipePortion(PLURAL_NO_ADDEND));
-        assertFalse(RecipePortion.isValidRecipePortion(TO_NO_WHITESPACE));
-        assertFalse(RecipePortion.isValidRecipePortion(INVALID_RANGE));
+    public void of_validInputs_RecipePortionCreated() {
+        assertEquals(RecipePortion.of(DASH_CONCAT), new RecipePortion(1, 2, new PortionUnit("servings")));
+        assertEquals(RecipePortion.of(TO_CONCAT), new RecipePortion(1, 2, new PortionUnit("servings")));
+        assertEquals(RecipePortion.of(DASH_WHITESPACE), new RecipePortion(1, 2, new PortionUnit("servings")));
+        assertEquals(RecipePortion.of(TO_WHITESPACE), new RecipePortion(1, 2, new PortionUnit("people")));
+        assertEquals(RecipePortion.of(SIMPLE_LOWER_RANGE), new RecipePortion(13, 0, new PortionUnit("serving sizes")));
+    }
 
-        assertTrue(RecipePortion.isValidRecipePortion(RANGE_CONCAT));
-        assertTrue(RecipePortion.isValidRecipePortion(RANGE_WHITESPACE));
-        assertTrue(RecipePortion.isValidRecipePortion(TO_WHITESPACE));
-        assertTrue(RecipePortion.isValidRecipePortion(SIMPLE_LOWER_RANGE));
-        assertTrue(RecipePortion.isValidRecipePortion(SIMPLE_LOWER_RANGE_PLURAL));
+    @Test
+    public void of_invalidInputs_exceptionThrown() {
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_EMPTY));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_NO_RANGE));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_NO_UNIT));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_RANGE));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_SIMPLE));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_EMPTY));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_DASH));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_TO));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_WHITESPACE));
+        assertThrows(IllegalArgumentException.class, () -> RecipePortion.of(INVALID_UNIT));
+
     }
 
     @Test
@@ -55,14 +67,6 @@ public class RecipePortionTest {
         assertDoesNotThrow(() -> new RecipePortion(1, 3, new PortionUnit("portions")));
     }
 
-    @Test
-    public void testFactory() {
-        //Redirection if regex fail
-        assertThrows(RecipePortionInvalidArgumentException.class, () -> RecipePortion.of(TO_NO_WHITESPACE));
-
-        assertDoesNotThrow(() -> RecipePortion.of(RANGE_CONCAT));
-        assertDoesNotThrow(() -> RecipePortion.of(SIMPLE_LOWER_RANGE));
-    }
 
     @Test
     public void testToString() {

--- a/src/test/java/seedu/recipe/model/recipe/RecipePortionTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/RecipePortionTest.java
@@ -28,7 +28,7 @@ public class RecipePortionTest {
     private static final String INVALID_UNIT = "13 - 15 of Granny's Friends";
 
     @Test
-    public void of_validInputs_RecipePortionCreated() {
+    public void of_validInputs_recipePortionCreated() {
         assertEquals(RecipePortion.of(DASH_CONCAT), new RecipePortion(1, 2, new PortionUnit("servings")));
         assertEquals(RecipePortion.of(TO_CONCAT), new RecipePortion(1, 2, new PortionUnit("servings")));
         assertEquals(RecipePortion.of(DASH_WHITESPACE), new RecipePortion(1, 2, new PortionUnit("servings")));

--- a/src/test/java/seedu/recipe/model/recipe/RecipeTest.java
+++ b/src/test/java/seedu/recipe/model/recipe/RecipeTest.java
@@ -73,10 +73,6 @@ public class RecipeTest {
         GRILLED_CHEESE.getDuration(), GRILLED_CHEESE.getTags(),
         GRILLED_CHEESE.getIngredients(), GRILLED_CHEESE.getSteps()).build();
 
-    private static final Recipe CACIO_TRAILING_SPACE = new RecipeBuilder(
-        new Name("Cacio e Pepe "), CACIO_E_PEPE.getPortion(),
-        CACIO_E_PEPE.getDuration(), CACIO_E_PEPE.getTags(),
-        CACIO_E_PEPE.getIngredients(), CACIO_E_PEPE.getSteps()).build();
 
     //Deep copying
     private static final Recipe CACIO_DEEP_COPY = new RecipeBuilder(
@@ -219,9 +215,6 @@ public class RecipeTest {
 
         // name differs in case, all other attributes same -> returns false
         assertFalse(GRILLED_CHEESE.isSameRecipe(GRILLED_CHEESE_DIFF_CASE));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        assertFalse(CACIO_E_PEPE.isSameRecipe(CACIO_TRAILING_SPACE));
     }
 
     @Test
@@ -264,10 +257,10 @@ public class RecipeTest {
     public void testHashCode() {
         HashMap<Ingredient, IngredientInformation> cacioIngredientTable = new HashMap<>();
         CACIO_INGREDIENTS.stream()
-                .map(IngredientBuilder::build)
-                .forEach(cacioIngredientTable::putAll);
+            .map(IngredientBuilder::build)
+            .forEach(cacioIngredientTable::putAll);
         int hash = Objects.hash(
-                CACIO_NAME, CACIO_PORTION, CACIO_DURATION, CACIO_TAGS, cacioIngredientTable, CACIO_STEPS);
+            CACIO_NAME, CACIO_PORTION, CACIO_DURATION, CACIO_TAGS, cacioIngredientTable, CACIO_STEPS);
         assertEquals(hash, CACIO_E_PEPE.hashCode());
     }
 

--- a/src/test/java/seedu/recipe/storage/JsonAdaptedRecipeTest.java
+++ b/src/test/java/seedu/recipe/storage/JsonAdaptedRecipeTest.java
@@ -40,30 +40,30 @@ import seedu.recipe.storage.jsonadapters.JsonAdaptedTag;
 import seedu.recipe.storage.jsonadapters.JsonAdaptedTimeUnit;
 
 public class JsonAdaptedRecipeTest {
-    private static final String INVALID_NAME = "7896";
+    private static final String INVALID_NAME = "Bobby`s 39th Birthday Cake";
     private static final JsonAdaptedRecipePortion INVALID_PORTION = new JsonAdaptedRecipePortion(
-            1, 0, new JsonAdaptedPortionUnit("unitName")
+        5, 3, new JsonAdaptedPortionUnit("unitName")
     );
     private static final JsonAdaptedRecipeDuration INVALID_DURATION = new JsonAdaptedRecipeDuration(
-            -1, new JsonAdaptedTimeUnit("minutes")
+        -1, new JsonAdaptedTimeUnit("minutes")
     );
     private static final String INVALID_TAG = "#lit";
     private static final JsonAdaptedIngredient INVALID_INGREDIENT =
-            new JsonAdaptedIngredient("", "", "1g", "", List.of(), List.of());
+        new JsonAdaptedIngredient("", "", "1g", "", List.of(), List.of());
 
     private static final String INVALID_STEP = "";
 
     private static List<JsonAdaptedIngredient> getIngredientList() {
         HashMap<Ingredient, IngredientInformation> ingredientTable = new HashMap<>();
         CACIO_INGREDIENTS.stream()
-                .map(IngredientBuilder::build)
-                .forEach(ingredientTable::putAll);
+            .map(IngredientBuilder::build)
+            .forEach(ingredientTable::putAll);
 
         return ingredientTable
-                .entrySet()
-                .stream()
-                .map(entry -> new JsonAdaptedIngredient(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
+            .entrySet()
+            .stream()
+            .map(entry -> new JsonAdaptedIngredient(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList());
     }
 
     @Test
@@ -77,12 +77,12 @@ public class JsonAdaptedRecipeTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(INVALID_NAME),
-                Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
-                Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                getIngredientList(),
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
+            new JsonAdaptedName(INVALID_NAME),
+            Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
+            Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            getIngredientList(),
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
         );
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
@@ -91,12 +91,12 @@ public class JsonAdaptedRecipeTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                null,
-                Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
-                Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                getIngredientList(),
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
+            null,
+            Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
+            Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            getIngredientList(),
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
         );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
@@ -105,12 +105,12 @@ public class JsonAdaptedRecipeTest {
     @Test
     public void toModelType_invalidPortion_throwsIllegalValueException() {
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(CACIO_NAME),
-                Optional.of(INVALID_PORTION),
-                Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                getIngredientList(),
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
+            new JsonAdaptedName(CACIO_NAME),
+            Optional.of(INVALID_PORTION),
+            Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            getIngredientList(),
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
         );
         String expectedMessage = RecipePortion.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
@@ -119,12 +119,12 @@ public class JsonAdaptedRecipeTest {
     @Test
     public void toModelType_nullPortion_throwsIllegalValueException() {
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(CACIO_NAME),
-                null,
-                Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                getIngredientList(),
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
+            new JsonAdaptedName(CACIO_NAME),
+            null,
+            Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            getIngredientList(),
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
         );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, RecipePortion.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
@@ -133,12 +133,12 @@ public class JsonAdaptedRecipeTest {
     @Test
     public void toModelType_invalidDuration_throwsIllegalValueException() {
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(CACIO_NAME),
-                Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
-                Optional.of(INVALID_DURATION),
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                getIngredientList(),
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
+            new JsonAdaptedName(CACIO_NAME),
+            Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
+            Optional.of(INVALID_DURATION),
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            getIngredientList(),
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
         );
         String expectedMessage = RecipeDuration.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
@@ -147,12 +147,12 @@ public class JsonAdaptedRecipeTest {
     @Test
     public void toModelType_nullDuration_throwsIllegalValueException() {
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(CACIO_NAME),
-                Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
-                null,
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                getIngredientList(),
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
+            new JsonAdaptedName(CACIO_NAME),
+            Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
+            null,
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            getIngredientList(),
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList())
         );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, RecipeDuration.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
@@ -163,12 +163,12 @@ public class JsonAdaptedRecipeTest {
         List<JsonAdaptedTag> invalidTags = CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList());
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(CACIO_NAME),
-                Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
-                Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
-                invalidTags,
-                getIngredientList(),
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList()));
+            new JsonAdaptedName(CACIO_NAME),
+            Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
+            Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
+            invalidTags,
+            getIngredientList(),
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList()));
         String expectedMessage = String.format(Tag.MESSAGE_CONSTRAINTS);
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
     }
@@ -178,28 +178,27 @@ public class JsonAdaptedRecipeTest {
         List<JsonAdaptedIngredient> invalidIngredients = getIngredientList();
         invalidIngredients.add(INVALID_INGREDIENT);
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(CACIO_NAME),
-                Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
-                Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                invalidIngredients,
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList()));
-        String expectedMessage = String.format(Ingredient.MESSAGE_CONSTRAINTS);
-        assertThrows(IllegalArgumentException.class, expectedMessage, recipe::toModelType);
+            new JsonAdaptedName(CACIO_NAME),
+            Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
+            Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            invalidIngredients,
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList()));
+        assertThrows(IllegalArgumentException.class, recipe::toModelType);
     }
 
     @Test
     public void toModelType_invalidSteps_throwsIllegalValueException() {
         List<JsonAdaptedStep> invalidSteps =
-                CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList());
+            CACIO_STEPS.stream().map(JsonAdaptedStep::new).collect(Collectors.toList());
         invalidSteps.add(new JsonAdaptedStep(INVALID_STEP));
         JsonAdaptedRecipe recipe = new JsonAdaptedRecipe(
-                new JsonAdaptedName(CACIO_NAME),
-                Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
-                Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
-                CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
-                getIngredientList(),
-                invalidSteps);
+            new JsonAdaptedName(CACIO_NAME),
+            Optional.of(CACIO_PORTION).map(JsonAdaptedRecipePortion::new),
+            Optional.of(CACIO_DURATION).map(JsonAdaptedRecipeDuration::new),
+            CACIO_TAGS.stream().map(JsonAdaptedTag::new).collect(Collectors.toList()),
+            getIngredientList(),
+            invalidSteps);
         String expectedMessage = String.format(Step.MESSAGE_CONSTRAINTS);
         assertThrows(IllegalValueException.class, expectedMessage, recipe::toModelType);
     }


### PR DESCRIPTION
Closes #243 #242 #234 #235 #215 #212 #217 #218 #241 #230 #221 #240

Task list (copied from issue):
- [x] `IllegalArgumentException` not caught when adding an invalid ingredient (242, 234)
- [x] More detailed error messages for ingredient parsers (235)
- [x] More detailed error messages in `edit` parsing (215, 212, 217)
- [x] More detailed error messages for `addf` command (218)
- [x] Fix regex parsing for `Name` class and ensure all regexes are documented in UG (241, 230)
- [x] Fix validation for `Portion` (221)
- [x] Fix validation for `Duration` (240)
- [x] Fix removing portions and durations from recipes by emptying the field OR passing in an empty string, e.g. `edit 1 p/ d/`
