### PR TITLE
V1.4: Full Coverage Tests for `Commons` package

### DIFF
--- a/src/main/java/seedu/recipe/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/recipe/commons/core/GuiSettings.java
@@ -30,6 +30,8 @@ public class GuiSettings implements Serializable {
      * Constructs a {@code GuiSettings} with the specified height, width and position.
      */
     public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition) {
+        assert windowWidth > 0;
+        assert windowHeight > 0;
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = new Point(xPosition, yPosition);

--- a/src/main/java/seedu/recipe/commons/core/Messages.java
+++ b/src/main/java/seedu/recipe/commons/core/Messages.java
@@ -4,7 +4,6 @@ package seedu.recipe.commons.core;
  * Container for user visible messages.
  */
 public class Messages {
-
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_EMPTY_KEYWORDS_FIND = "Keywords for the find command cannot be empty!";

--- a/src/main/java/seedu/recipe/storage/JsonSerializableRecipeBook.java
+++ b/src/main/java/seedu/recipe/storage/JsonSerializableRecipeBook.java
@@ -18,7 +18,7 @@ import seedu.recipe.storage.jsonadapters.JsonAdaptedRecipe;
  * An Immutable RecipeBook that is serializable to JSON format.
  */
 @JsonRootName(value = "recipebook")
-class JsonSerializableRecipeBook {
+public class JsonSerializableRecipeBook {
 
     public static final String MESSAGE_DUPLICATE_RECIPE = "Recipes list contains duplicate recipe(s).";
 

--- a/src/test/java/seedu/recipe/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/recipe/commons/core/ConfigTest.java
@@ -11,12 +11,17 @@ import java.util.logging.Level;
 import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
-    private static final Path USER_PREFS_FILE_PATH = Paths.get("preferences.json");
+    //Test base config
+    private static final String USER_PREFS_FILE_PATH_STRING = "preferences.json";
+    private static final Path USER_PREFS_FILE_PATH = Paths.get(USER_PREFS_FILE_PATH_STRING);
+    private static final Level CONFIG_BASE_LEVEL = Level.INFO;
+    private static final String DEFAULT_CONFIG_STRING = String.format("Current log level : %s\n"
+        + "Preference file Location : %s", CONFIG_BASE_LEVEL, USER_PREFS_FILE_PATH_STRING);
 
     @Test
     public void test_getLogLevel_initialInfo() {
         Config defaultConfig = new Config();
-        assertEquals(defaultConfig.getLogLevel(), Level.INFO);
+        assertEquals(defaultConfig.getLogLevel(), CONFIG_BASE_LEVEL);
     }
 
     @Test
@@ -48,14 +53,11 @@ public class ConfigTest {
 
     @Test
     public void test_hashCode() {
-        assertEquals(Objects.hash(Level.INFO, USER_PREFS_FILE_PATH), new Config().hashCode());
+        assertEquals(Objects.hash(CONFIG_BASE_LEVEL, USER_PREFS_FILE_PATH), new Config().hashCode());
     }
 
     @Test
     public void toString_defaultObject_stringReturned() {
-        String defaultConfigAsString = "Current log level : INFO\n"
-                + "Preference file Location : preferences.json";
-
-        assertEquals(defaultConfigAsString, new Config().toString());
+        assertEquals(DEFAULT_CONFIG_STRING, new Config().toString());
     }
 }

--- a/src/test/java/seedu/recipe/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/recipe/commons/core/ConfigTest.java
@@ -2,11 +2,54 @@ package seedu.recipe.commons.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.logging.Level;
 
 import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
+    private static final Path USER_PREFS_FILE_PATH = Paths.get("preferences.json");
+
+    @Test
+    public void test_getLogLevel_initialInfo() {
+        Config defaultConfig = new Config();
+        assertEquals(defaultConfig.getLogLevel(), Level.INFO);
+    }
+
+    @Test
+    public void test_setLogLevel() {
+        Config defaultConfig = new Config();
+        defaultConfig.setLogLevel(Level.WARNING);
+        assertEquals(defaultConfig.getLogLevel(), Level.WARNING);
+    }
+
+    @Test
+    public void test_getUserPrefsPath() {
+        assertEquals(USER_PREFS_FILE_PATH, new Config().getUserPrefsFilePath());
+    }
+
+    @Test
+    public void test_setUserPrefsFilePath() {
+        Path newPath = Paths.get("null path");
+        Config defaultConfig = new Config();
+        defaultConfig.setUserPrefsFilePath(newPath);
+        assertEquals(defaultConfig.getUserPrefsFilePath(), newPath);
+    }
+
+    @Test
+    public void equalsMethod() {
+        Config defaultConfig = new Config();
+        assertNotNull(defaultConfig);
+        assertEquals(defaultConfig, defaultConfig);
+    }
+
+    @Test
+    public void test_hashCode() {
+        assertEquals(Objects.hash(Level.INFO, USER_PREFS_FILE_PATH), new Config().hashCode());
+    }
 
     @Test
     public void toString_defaultObject_stringReturned() {
@@ -15,13 +58,4 @@ public class ConfigTest {
 
         assertEquals(defaultConfigAsString, new Config().toString());
     }
-
-    @Test
-    public void equalsMethod() {
-        Config defaultConfig = new Config();
-        assertNotNull(defaultConfig);
-        assertTrue(defaultConfig.equals(defaultConfig));
-    }
-
-
 }

--- a/src/test/java/seedu/recipe/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/recipe/commons/core/GuiSettingsTest.java
@@ -1,0 +1,91 @@
+package seedu.recipe.commons.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Contains tests that validate that the GuiSettings class performs as expected.
+ * If the developer wishes to modify the class defaults or behaviors, they will
+ * have to modify these test cases.
+ */
+public class GuiSettingsTest {
+    private static final double DEFAULT_HEIGHT = 600;
+    private static final double DEFAULT_WIDTH = 740;
+
+    @Test
+    public void testDefaultConstructor() {
+        GuiSettings settings = new GuiSettings();
+        assertEquals(settings.getWindowHeight(), DEFAULT_HEIGHT);
+        assertEquals(settings.getWindowWidth(), DEFAULT_WIDTH);
+        assertNull(settings.getWindowCoordinates());
+    }
+
+    @Test
+    public void testOverloadedConstructor() {
+        AtomicReference<GuiSettings> settings = new AtomicReference<>();
+        //Validate valid values work
+        assertDoesNotThrow(() -> {
+            settings.set(new GuiSettings(1, 1, 0, 0));
+        });
+
+        //Validate invalid width throws error
+        assertThrows(AssertionError.class, () -> settings.set(new GuiSettings(0, 1, 0, 0)));
+        assertThrows(AssertionError.class, () -> settings.set(new GuiSettings(-1, 1, 0, 0)));
+        //Validate invalid height throws error
+        assertThrows(AssertionError.class, () -> settings.set(new GuiSettings(1, 0, 0, 0)));
+        assertThrows(AssertionError.class, () -> settings.set(new GuiSettings(1, -1, 0, 0)));
+
+        //Test with valid values, diff x, y coordinates
+        assertDoesNotThrow(() -> settings.set(new GuiSettings(1, 1, 1, 0)));
+        assertDoesNotThrow(() -> settings.set(new GuiSettings(1, 1, -1, 0)));
+        assertDoesNotThrow(() -> settings.set(new GuiSettings(1, 1, 0, -1)));
+        assertDoesNotThrow(() -> settings.set(new GuiSettings(1, 1, 0, 1)));
+
+        //Test that the last Point was initialised properly
+        assertEquals(new Point(0, 1), settings.get().getWindowCoordinates());
+        assertEquals(1, settings.get().getWindowHeight());
+        assertEquals(1, settings.get().getWindowWidth());
+    }
+
+    @Test
+    public void testEquals() {
+        GuiSettings settingAlpha = new GuiSettings(10, 5, 0, 5);
+        GuiSettings settingAlphaCopy = new GuiSettings(10, 5, 0, 5);
+        GuiSettings settingAlphaDiff = new GuiSettings(10, 5, 1, 5);
+
+        assertEquals(settingAlphaCopy, settingAlpha);
+        assertEquals(settingAlpha, settingAlpha);
+        assertNotEquals(settingAlpha, settingAlphaDiff);
+    }
+
+    @Test
+    public void test_hashCode() {
+        double height = 100.0;
+        double width = 50.0;
+        int xCoord = 20;
+        int yCoord = -15;
+        assertEquals(Objects.hash(height, width, new Point(xCoord, yCoord)),
+            new GuiSettings(height, width, xCoord, yCoord).hashCode());
+    }
+
+    @Test
+    public void test_string() {
+        double height = 100.0;
+        double width = 50.0;
+        int xCoord = 20;
+        int yCoord = -15;
+        String expectedFmt = String.format("Width : %s\nHeight : %s\nPosition : %s",
+            width, height, new Point(xCoord, yCoord));
+        assertEquals(expectedFmt, new GuiSettings(width, height, xCoord, yCoord).toString());
+    }
+}

--- a/src/test/java/seedu/recipe/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/recipe/commons/core/GuiSettingsTest.java
@@ -33,6 +33,7 @@ public class GuiSettingsTest {
 
     @Test
     public void testOverloadedConstructor() {
+        //Referential consistency for Runnable Lambdas passed to assert statements
         AtomicReference<GuiSettings> settings = new AtomicReference<>();
         //Validate valid values work
         assertDoesNotThrow(() -> {
@@ -74,20 +75,20 @@ public class GuiSettingsTest {
     public void test_hashCode() {
         double height = 100.0;
         double width = 50.0;
-        int xCoord = 20;
-        int yCoord = -15;
-        assertEquals(Objects.hash(height, width, new Point(xCoord, yCoord)),
-            new GuiSettings(height, width, xCoord, yCoord).hashCode());
+        int xCoordinate = 20;
+        int yCoordinate = -15;
+        assertEquals(Objects.hash(width, height, new Point(xCoordinate, yCoordinate)),
+            new GuiSettings(width, height, xCoordinate, yCoordinate).hashCode());
     }
 
     @Test
     public void test_string() {
         double height = 100.0;
         double width = 50.0;
-        int xCoord = 20;
-        int yCoord = -15;
+        int xCoordinate = 20;
+        int yCoordinate = -15;
         String expectedFmt = String.format("Width : %s\nHeight : %s\nPosition : %s",
-            width, height, new Point(xCoord, yCoord));
-        assertEquals(expectedFmt, new GuiSettings(width, height, xCoord, yCoord).toString());
+            width, height, new Point(xCoordinate, yCoordinate));
+        assertEquals(expectedFmt, new GuiSettings(width, height, xCoordinate, yCoordinate).toString());
     }
 }

--- a/src/test/java/seedu/recipe/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/recipe/commons/core/GuiSettingsTest.java
@@ -1,17 +1,18 @@
 package seedu.recipe.commons.core;
 
-import org.junit.jupiter.api.Test;
-
-import java.awt.*;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.awt.Point;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Contains tests that validate that the GuiSettings class performs as expected.
@@ -52,6 +53,7 @@ public class GuiSettingsTest {
         assertDoesNotThrow(() -> settings.set(new GuiSettings(1, 1, 0, 1)));
 
         //Test that the last Point was initialised properly
+        assertNotNull(settings.get().getWindowCoordinates());
         assertEquals(new Point(0, 1), settings.get().getWindowCoordinates());
         assertEquals(1, settings.get().getWindowHeight());
         assertEquals(1, settings.get().getWindowWidth());

--- a/src/test/java/seedu/recipe/commons/core/MessagesTest.java
+++ b/src/test/java/seedu/recipe/commons/core/MessagesTest.java
@@ -1,0 +1,67 @@
+package seedu.recipe.commons.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Container for test methods that validate that the Messages provided to the Application are valid.
+ * If a developer has to modify the actual message, the test case here has to be fixed before those changes
+ * are merged with the production code.
+ */
+public class MessagesTest {
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_EMPTY_KEYWORDS_FIND = "Keywords for the find command cannot be empty!";
+    public static final String MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX = "The recipe index provided is invalid";
+    public static final String MESSAGE_RECIPES_LISTED_OVERVIEW = "%1$d recipes listed!";
+    public static final String MESSAGE_NO_STORED_SUBS = "No substitutions are available. Check back later or "
+            + "update the RecipeBook with some suggested substitutions!";
+    public static final String MESSAGE_DISPLAY_STORED_SUBS = "Here's a list of potential substitutes for the "
+            + "ingredient %s: \n%s";
+
+    @Test
+    public void test_unknownCommand() {
+        assertEquals(MESSAGE_UNKNOWN_COMMAND, Messages.MESSAGE_UNKNOWN_COMMAND);
+    }
+
+    @Test
+    public void test_invalidCommandFormat() {
+        String testMessage = "Aa{bC}/:;\\|`'";
+        assertEquals(MESSAGE_INVALID_COMMAND_FORMAT, Messages.MESSAGE_INVALID_COMMAND_FORMAT);
+        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, testMessage),
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, testMessage));
+    }
+
+    @Test
+    public void test_emptyKeywordsFind() {
+        assertEquals(MESSAGE_EMPTY_KEYWORDS_FIND, Messages.MESSAGE_EMPTY_KEYWORDS_FIND);
+    }
+
+    @Test
+    public void test_invalidRecipeIndex() {
+        assertEquals(MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX, Messages.MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void test_recipesListedOverview() {
+        Integer testNumber = 22;
+        assertEquals(MESSAGE_RECIPES_LISTED_OVERVIEW, Messages.MESSAGE_RECIPES_LISTED_OVERVIEW);
+        assertEquals(String.format(MESSAGE_RECIPES_LISTED_OVERVIEW, testNumber),
+                String.format(Messages.MESSAGE_RECIPES_LISTED_OVERVIEW, testNumber));
+    }
+
+    @Test
+    public void test_noStoredSubs() {
+        assertEquals(MESSAGE_NO_STORED_SUBS, Messages.MESSAGE_NO_STORED_SUBS);
+    }
+
+    @Test
+    public void test_displayStoredSubs() {
+        String firstIngredient = "smoked halibut";
+        String subIngredient = "smoked salmon";
+        assertEquals(MESSAGE_DISPLAY_STORED_SUBS, Messages.MESSAGE_DISPLAY_STORED_SUBS);
+        assertEquals(String.format(MESSAGE_DISPLAY_STORED_SUBS, firstIngredient, subIngredient),
+            String.format(Messages.MESSAGE_DISPLAY_STORED_SUBS, firstIngredient, subIngredient));
+    }
+}

--- a/src/test/java/seedu/recipe/commons/core/VersionTest.java
+++ b/src/test/java/seedu/recipe/commons/core/VersionTest.java
@@ -1,6 +1,7 @@
 package seedu.recipe.commons.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.recipe.testutil.Assert.assertThrows;
 
@@ -121,11 +122,14 @@ public class VersionTest {
 
         one = new Version(0, 0, 0, false);
         another = new Version(0, 0, 0, false);
-        assertTrue(one.equals(another));
+        assertEquals(one, another);
 
         one = new Version(100, 191, 275, true);
         another = new Version(100, 191, 275, true);
-        assertTrue(one.equals(another));
+        assertEquals(one, another);
+
+        assertNotEquals(one, null); //null
+        assertNotEquals(one, ""); //type
     }
 
     private void verifyVersionParsedCorrectly(String versionString,

--- a/src/test/java/seedu/recipe/commons/exceptions/CommonsExceptionsTest.java
+++ b/src/test/java/seedu/recipe/commons/exceptions/CommonsExceptionsTest.java
@@ -15,7 +15,8 @@ public class CommonsExceptionsTest {
         String testMessage = "Test message";
         Exception wrappedException = new Exception(testMessage);
         DataConversionException e = new DataConversionException(wrappedException);
-        assertEquals("java.lang.Exception: " + testMessage, e.getMessage());
+        assertEquals(String.format("%s: %s", wrappedException.getClass().getCanonicalName(), testMessage),
+                e.getMessage());
         assertEquals(wrappedException, e.getCause());
     }
 

--- a/src/test/java/seedu/recipe/commons/exceptions/CommonsExceptionsTest.java
+++ b/src/test/java/seedu/recipe/commons/exceptions/CommonsExceptionsTest.java
@@ -1,0 +1,32 @@
+package seedu.recipe.commons.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CommonsExceptionsTest {
+    @Test
+    public void testDataConversionException_constructor() {
+        //Null value
+        assertDoesNotThrow(() -> new DataConversionException(null));
+
+        //Construct with test message, test Message and Cause
+        String testMessage = "Test message";
+        Exception wrappedException = new Exception(testMessage);
+        DataConversionException e = new DataConversionException(wrappedException);
+        assertEquals("java.lang.Exception: " + testMessage, e.getMessage());
+        assertEquals(wrappedException, e.getCause());
+    }
+
+    @Test
+    public void testIllegalValueException_constructor() {
+        String testMessage = "Test message";
+        assertEquals(testMessage, new IllegalValueException(testMessage).getMessage());
+
+        Exception wrappedException = new Exception(testMessage);
+        assertEquals(testMessage, new IllegalValueException(testMessage, wrappedException).getMessage());
+        assertEquals(wrappedException, new IllegalValueException(testMessage, wrappedException).getCause());
+    }
+}

--- a/src/test/java/seedu/recipe/commons/exceptions/CommonsExceptionsTest.java
+++ b/src/test/java/seedu/recipe/commons/exceptions/CommonsExceptionsTest.java
@@ -2,7 +2,6 @@ package seedu.recipe.commons.exceptions;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/recipe/commons/util/ConfigUtilTest.java
+++ b/src/test/java/seedu/recipe/commons/util/ConfigUtilTest.java
@@ -17,7 +17,6 @@ import seedu.recipe.commons.core.Config;
 import seedu.recipe.commons.exceptions.DataConversionException;
 
 public class ConfigUtilTest {
-
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "ConfigUtilTest");
 
     @TempDir

--- a/src/test/java/seedu/recipe/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/recipe/commons/util/FileUtilTest.java
@@ -4,9 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.recipe.testutil.Assert.assertThrows;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Test;
 
 public class FileUtilTest {
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonSerializableRecipeBookTest");
+    private static final Path VALID_PATH = TEST_DATA_FOLDER.resolve("typicalRecipeRecipeBook.json");
+
+    @Test
+    public void isFileExists() {
+        assertTrue(FileUtil.isFileExists(VALID_PATH));
+    }
 
     @Test
     public void isValidPath() {

--- a/src/test/java/seedu/recipe/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/recipe/commons/util/FileUtilTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.recipe.testutil.Assert.assertThrows;
 
 import java.io.IOException;
@@ -41,8 +42,10 @@ public class FileUtilTest {
     public void isFileExists() {
         //Valid file exists
         assertTrue(FileUtil.isFileExists(VALID_PATH));
+
         //irregular file (Folder), exists
         assertFalse(FileUtil.isFileExists(TEST_DATA_FOLDER));
+
         //File does not exist
         assertFalse(FileUtil.isFileExists(Paths.get("doesNotExist")));
     }
@@ -63,12 +66,14 @@ public class FileUtilTest {
     public void createFile_createParentFile() {
         //New file, both parent folder and file should not error
         assertDoesNotThrow(() -> FileUtil.createFile(TEST_NEW_FILE));
+
         //Files should exist
         assertTrue(FileUtil.isFileExists(TEST_NEW_FILE));
     }
 
     @Test
     public void testCreateIfMissing() {
+        //Create, and test that it is created.
         assertDoesNotThrow(() -> FileUtil.createIfMissing(TEST_NEW_FILE));
         assertTrue(FileUtil.isFileExists(TEST_NEW_FILE));
     }
@@ -77,14 +82,17 @@ public class FileUtilTest {
     public void readWrite() {
         String testString = "hello world";
         assertDoesNotThrow(() -> FileUtil.createFile(TEST_NEW_FILE));
+
         //Writing to a valid file should work
         assertDoesNotThrow(() -> FileUtil.writeToFile(TEST_NEW_FILE, testString));
+
         //Validate what was written
         assertDoesNotThrow(() -> FileUtil.readFromFile(TEST_NEW_FILE));
+
         try {
             assertEquals(testString, FileUtil.readFromFile(TEST_NEW_FILE));
         } catch (IOException e) {
-            assert false;
+            fail();
         }
     }
 }

--- a/src/test/java/seedu/recipe/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/recipe/commons/util/FileUtilTest.java
@@ -1,21 +1,50 @@
 package seedu.recipe.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.recipe.testutil.Assert.assertThrows;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains test cases that validate the FileUtils class and its methods'
+ * behavior.
+ * If the developer modifies those behaviors, they are to modify these
+ * test cases as well before their code is merged into the production build.
+ */
 public class FileUtilTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonSerializableRecipeBookTest");
     private static final Path VALID_PATH = TEST_DATA_FOLDER.resolve("typicalRecipeRecipeBook.json");
 
+    private static final Path TEST_NEW_FOLDER = Paths.get("src", "test", "data", "fileUtils");
+    private static final Path TEST_NEW_FILE = TEST_NEW_FOLDER.resolve("test.txt");
+
+    @AfterEach
+    public void deleteTestFiles() {
+        try {
+            Files.delete(TEST_NEW_FILE);
+            Files.delete(TEST_NEW_FOLDER);
+        } catch (IOException ignored) {
+            //Pass, already deleted
+        }
+    }
+
     @Test
     public void isFileExists() {
+        //Valid file exists
         assertTrue(FileUtil.isFileExists(VALID_PATH));
+        //irregular file (Folder), exists
+        assertFalse(FileUtil.isFileExists(TEST_DATA_FOLDER));
+        //File does not exist
+        assertFalse(FileUtil.isFileExists(Paths.get("doesNotExist")));
     }
 
     @Test
@@ -30,4 +59,32 @@ public class FileUtilTest {
         assertThrows(NullPointerException.class, () -> FileUtil.isValidPath(null));
     }
 
+    @Test
+    public void createFile_createParentFile() {
+        //New file, both parent folder and file should not error
+        assertDoesNotThrow(() -> FileUtil.createFile(TEST_NEW_FILE));
+        //Files should exist
+        assertTrue(FileUtil.isFileExists(TEST_NEW_FILE));
+    }
+
+    @Test
+    public void testCreateIfMissing() {
+        assertDoesNotThrow(() -> FileUtil.createIfMissing(TEST_NEW_FILE));
+        assertTrue(FileUtil.isFileExists(TEST_NEW_FILE));
+    }
+
+    @Test
+    public void readWrite() {
+        String testString = "hello world";
+        assertDoesNotThrow(() -> FileUtil.createFile(TEST_NEW_FILE));
+        //Writing to a valid file should work
+        assertDoesNotThrow(() -> FileUtil.writeToFile(TEST_NEW_FILE, testString));
+        //Validate what was written
+        assertDoesNotThrow(() -> FileUtil.readFromFile(TEST_NEW_FILE));
+        try {
+            assertEquals(testString, FileUtil.readFromFile(TEST_NEW_FILE));
+        } catch (IOException e) {
+            assert false;
+        }
+    }
 }

--- a/src/test/java/seedu/recipe/commons/util/JsonUtilTest.java
+++ b/src/test/java/seedu/recipe/commons/util/JsonUtilTest.java
@@ -1,12 +1,22 @@
 package seedu.recipe.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.recipe.testutil.TypicalRecipes.getTypicalRecipeBook;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.recipe.commons.exceptions.DataConversionException;
+import seedu.recipe.commons.exceptions.IllegalValueException;
+import seedu.recipe.storage.JsonSerializableRecipeBook;
 import seedu.recipe.testutil.SerializableTestClass;
 import seedu.recipe.testutil.TestUtil;
 
@@ -16,6 +26,8 @@ import seedu.recipe.testutil.TestUtil;
 public class JsonUtilTest {
 
     private static final Path SERIALIZATION_FILE = TestUtil.getFilePathInSandboxFolder("serialize.json");
+    private static final Path TYPICAL_RECIPE_BOOK = Paths.get("src", "test", "data",
+        "JsonSerializableRecipeBookTest", "typicalRecipeRecipeBook.json");
 
     @Test
     public void serializeObjectToJsonFile_noExceptionThrown() throws IOException {
@@ -39,7 +51,24 @@ public class JsonUtilTest {
         assertEquals(serializableTestClass.getMapOfIntegerToString(), SerializableTestClass.getHashMapTestValues());
     }
 
-    //TODO: @Test jsonUtil_readJsonStringToObjectInstance_correctObject()
+    @Test
+    public void test_readJsonFile() {
+        //Test read valid file
+        try {
+            Optional<JsonSerializableRecipeBook> serializableRecipeBook =
+                JsonUtil.readJsonFile(TYPICAL_RECIPE_BOOK, JsonSerializableRecipeBook.class);
+            assertEquals(getTypicalRecipeBook(), serializableRecipeBook.get().toModelType());
+        } catch (DataConversionException | IllegalValueException e) {
+            assert false;
+        }
+        //Test null
+        assertThrows(NullPointerException.class, () -> JsonUtil.readJsonFile(null, Object.class));
 
-    //TODO: @Test jsonUtil_writeThenReadObjectToJson_correctObject()
+        //Test does not exist
+        try {
+            assertTrue(JsonUtil.readJsonFile(Paths.get("doesNotExist"), Object.class).isEmpty());
+        } catch (DataConversionException ignored) { // Will never reach here, as file does not exist.
+            assert false;
+        }
+    }
 }

--- a/src/test/java/seedu/recipe/commons/util/JsonUtilTest.java
+++ b/src/test/java/seedu/recipe/commons/util/JsonUtilTest.java
@@ -3,6 +3,7 @@ package seedu.recipe.commons.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.recipe.testutil.TypicalRecipes.getTypicalRecipeBook;
 
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class JsonUtilTest {
                 JsonUtil.readJsonFile(TYPICAL_RECIPE_BOOK, JsonSerializableRecipeBook.class);
             assertEquals(getTypicalRecipeBook(), serializableRecipeBook.get().toModelType());
         } catch (DataConversionException | IllegalValueException e) {
-            assert false;
+            fail();
         }
         //Test null
         assertThrows(NullPointerException.class, () -> JsonUtil.readJsonFile(null, Object.class));
@@ -66,7 +67,7 @@ public class JsonUtilTest {
         try {
             assertTrue(JsonUtil.readJsonFile(Paths.get("doesNotExist"), Object.class).isEmpty());
         } catch (DataConversionException ignored) { // Will never reach here, as file does not exist.
-            assert false;
+            fail();
         }
     }
 }

--- a/src/test/java/seedu/recipe/commons/util/JsonUtilTest.java
+++ b/src/test/java/seedu/recipe/commons/util/JsonUtilTest.java
@@ -1,6 +1,5 @@
 package seedu.recipe.commons.util;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,7 +8,6 @@ import static seedu.recipe.testutil.TypicalRecipes.getTypicalRecipeBook;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
To add tests for this package, as well for each of its sub packages:
- [x] `commons.core`
  - Effort to reward ratio for LogsCenter to be re-evaluated
- [x] `commons.core.index`
- [x] `commons.exception`
- [x] `commons.utils`
  - [x] `commons.utils.FileUtils`
  - [x] `commons.utils.JsonUtils` 
  
## **Final Statistics**
  | Class | Method | Line |
  |--|--|--|
  | 93% (28/30) | 97% (146/150) | 95% (436/458) |